### PR TITLE
feat(plugin): support globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@crowdin/crowdin-api-client": "^1.22.2",
     "deep-equal": "^2.2.1",
+    "lodash": "^4.17.21",
     "payload": "^1.8.3",
     "slate-serializers": "^0.0.32"
   },

--- a/src/fields/getFields.ts
+++ b/src/fields/getFields.ts
@@ -1,9 +1,7 @@
-import type { FieldHook } from 'payload/dist/fields/config/types'
-import type { CollectionConfig, Field} from 'payload/types'
-import { containsLocalizedFields, isLocalizedField } from '../utilities'
+import type { CollectionConfig, Field, GlobalConfig} from 'payload/types'
 
 interface Args {
-  collection: CollectionConfig
+  collection: CollectionConfig | GlobalConfig
 }
 
 export const getFields = ({

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,4 +1,4 @@
-import { CollectionConfig, Field } from 'payload/types'
+import { CollectionConfig, Field, GlobalConfig } from 'payload/types'
 import deepEqual from 'deep-equal'
 import { FieldWithName } from '../types'
 import { slateToHtml, payloadSlateToDomConfig } from 'slate-serializers'
@@ -9,7 +9,7 @@ const localizedFieldTypes = [
   'text'
 ]
 
-export const getLocalizedFields = (collection: CollectionConfig, type?: 'json' | 'html'): any[] => {
+export const getLocalizedFields = (collection: CollectionConfig | GlobalConfig, type?: 'json' | 'html'): any[] => {
   const fields = [...collection.fields].filter(field => isLocalizedField(field))
   if (type) {
     return fields.filter(field => fieldCrowdinFileType(field as FieldWithName) === type)


### PR DESCRIPTION
Work with the existing logic (which desperately needs tests added and refactoring!) to add support for [globals](https://payloadcms.com/docs/configuration/globals).

Global support is straightforward to add . Most of the logic remains the same but there are some tweaks to ensure some different behaviour for globals:

- Store globals in the same CrowdIn collection directory (`globals`).
- Create CrowdIn collection directories that are named based on the global slug. e.g. `test-content` (this creates a name of `Test content` for CrowdIn to keep the naming scheme clean).