### PR TITLE
fix(buildjsoncrowdinobject): works with empty fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-crowdin-sync",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Automatically upload/sync localized fields from the default locale to CrowdIn. Make these fields read-only in other locales and update them using CrowdIn translations.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utilities/buildJsonCrowdinObject.spec.ts
+++ b/src/utilities/buildJsonCrowdinObject.spec.ts
@@ -282,7 +282,7 @@ describe("Function: buildCrowdinJsonObject", () => {
   })
 })
 
-describe("Function: buildCrowdinJsonObject - double nested", () => {
+describe("Function: buildCrowdinJsonObject - group nested in array", () => {
   const doc = {
     "id": "6474a81bef389b66642035ff",
     "title": "Experience the magic of our product!",
@@ -411,5 +411,48 @@ describe("Function: buildCrowdinJsonObject - double nested", () => {
         fields: getLocalizedFields({ fields: Promos.fields })
       , type: 'json'})
     )).toEqual(expected)
+  })
+
+  /**
+   * afterChange builds a JSON object for the previous version of
+   * a document to compare with the current version. Ensure this
+   * function works in that scenario. Also important for dealing
+   * with non-required empty fields.
+   */
+  it('can work with an empty document', () => {
+    expect(buildCrowdinJsonObject({},
+      getLocalizedFields({ fields: Promos.fields })
+    )).toEqual({})
+  })
+
+  it('can work with an empty array field', () => {
+    expect(buildCrowdinJsonObject({
+      ...doc,
+      ctas: undefined,
+    },
+      getLocalizedFields({ fields: Promos.fields })
+    )).toEqual({
+      "text": "Get in touch with us or try it out yourself",
+      "title": "Experience the magic of our product!"
+    })
+  })
+
+  it('can work with an empty group field in an array', () => {
+    expect(buildCrowdinJsonObject({
+      ...doc,
+      ctas: [
+        {},
+        {}
+      ],
+    },
+      getLocalizedFields({ fields: Promos.fields })
+    )).toEqual({
+      ctas: [
+        {},
+        {}
+      ],
+      "text": "Get in touch with us or try it out yourself",
+      "title": "Experience the magic of our product!"
+    })
   })
 })

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -102,6 +102,9 @@ export const buildCrowdinJsonObject = (doc: { [key: string]: any }, localizedFie
   let response: { [key: string]: any } = {}
   getLocalizedFields({ fields: localizedFields, type: 'json'})
     .forEach(field => {
+    if (!doc[field.name]) {
+      return
+    }
     if (field.type === 'group') {
       response[field.name] = buildCrowdinJsonObject(doc[field.name], field.fields)
     } else if (field.type === 'array') {


### PR DESCRIPTION
Avoid errors building CrowdIn JSON objects when fields are empty.

## Details

The `afterChange` hook builds a JSON object for the previous version of a document to compare with the current version.

For new documents, all fields will be empty. Furthermore, depending on which fields are required, some update operations will have empty fields.

Ensure an appropriate JSON object is built in these scenarios.