### PR TITLE
feat(*): support localization setting nested-field fields

### DIFF
--- a/src/api/payload.ts
+++ b/src/api/payload.ts
@@ -502,7 +502,10 @@ export async function getCurrentDocumentTranslation({
     htmlFields[field.name] = document[field.name]
   ))
   return {
-    ...buildCrowdinJsonObject(document, localizedFields),
+    ...buildCrowdinJsonObject({
+      doc: document,
+      fields: localizedFields
+    }),
     ...htmlFields
   }
 }

--- a/src/hooks/collections/afterChange.ts
+++ b/src/hooks/collections/afterChange.ts
@@ -1,7 +1,7 @@
 import { CollectionAfterChangeHook, CollectionConfig, Field, GlobalConfig, GlobalAfterChangeHook, PayloadRequest } from 'payload/types';
 import { CrowdinPluginRequest, FieldWithName } from '../../types'
 import { findOrCreateArticleDirectory, payloadCreateCrowdInFile, payloadUpdateCrowdInFile, getCrowdinFile } from '../../api/payload'
-import { buildCrowdinHtmlObject, buildCrowdinJsonObject, containsNestedFields, convertSlateToHtml, fieldChanged, getLocalizedFields } from '../../utilities'
+import { buildCrowdinHtmlObject, buildCrowdinJsonObject, convertSlateToHtml, fieldChanged, getLocalizedFields } from '../../utilities'
 import deepEqual from 'deep-equal'
 import dot from "dot-object"
 
@@ -116,14 +116,16 @@ const performAfterChange = async ({
     return doc
   }
 
+  console.log(getLocalizedFields({ fields: localizedFields, type: 'html'}))
+
   /**
    * Prepare JSON objects
    * 
    * `text` fields are compiled into a single JSON file
    * on CrowdIn. Prepare previous and current objects.
    */
-  const currentCrowdinJsonData = buildCrowdinJsonObject(doc, localizedFields as FieldWithName[])
-  const prevCrowdinJsonData = buildCrowdinJsonObject(previousDoc, localizedFields as FieldWithName[])
+  const currentCrowdinJsonData = buildCrowdinJsonObject({doc, fields: localizedFields})
+  const prevCrowdinJsonData = buildCrowdinJsonObject({doc: previousDoc, fields: localizedFields})
   /**
    * Retrieve the CrowdIn Article Directory article
    * 
@@ -199,11 +201,13 @@ const performAfterChange = async ({
       doc: previousDoc,
       fields: localizedFields,
     })
+    console.log(currentCrowdinHtmlData)
     Object.keys(currentCrowdinHtmlData).forEach(async name => {
       const crowdinFile = await getCrowdinFile(name, articleDirectory.id, req.payload)
       const currentValue = currentCrowdinHtmlData[name]
       const prevValue = prevCrowdinHtmlData[name]
       if (!fieldChanged(prevValue, currentValue, 'richText')) {
+        console.log(`${name} not changed`)
         return
       }
       if (typeof crowdinFile === 'undefined') {

--- a/src/utilities/buildHtmlCrowdinObject.spec.ts
+++ b/src/utilities/buildHtmlCrowdinObject.spec.ts
@@ -1,5 +1,5 @@
-import { CollectionConfig, Field } from "payload/types"
-import { buildCrowdinHtmlObject } from "."
+import { CollectionConfig, Field, GlobalConfig } from "payload/types"
+import { buildCrowdinHtmlObject, getLocalizedFields } from "."
 
 describe("fn: buildCrowdinHtmlObject", () => {
   it ("does not include undefined localized fields", () => {
@@ -197,6 +197,16 @@ describe("fn: buildCrowdinHtmlObject", () => {
         type: 'group',
         fields: [
           {
+            admin: {
+             elements: [
+               "link",
+             ],
+             leaves: [
+               "bold",
+               "italic",
+               "underline",
+             ],
+            },
             name: 'title',
             type: 'richText',
             localized: true,
@@ -211,6 +221,127 @@ describe("fn: buildCrowdinHtmlObject", () => {
             name: 'select',
             type: 'select',
             localized: true,
+            options: [
+              'one',
+              'two'
+            ]
+          },
+        ]
+      },
+    ]
+    const expected = {
+      ['groupField.title']: [
+        {
+          "type": "h1",
+          "children": [
+            {
+                "text": "A "
+            },
+            {
+                "text": "test",
+                "bold": true
+            },
+            {
+                "text": " rich text value"
+            }
+          ]
+        }
+      ],
+      ['groupField.content']: [
+        {
+          "type": "p",
+          "children": [
+            {
+                "text": "A simple paragraph."
+            },
+          ]
+        }
+      ],
+    }
+    expect(buildCrowdinHtmlObject({doc, fields})).toEqual(expected)
+  })
+
+  it ("includes localized fields nested in a group with a localization setting on the group field", () => {
+    const doc = {
+      id: '638641358b1a140462752076',
+      title: 'Test Policy created with title',
+      groupField: {
+        title: [
+          {
+            "type": "h1",
+            "children": [
+              {
+                  "text": "A "
+              },
+              {
+                  "text": "test",
+                  "bold": true
+              },
+              {
+                  "text": " rich text value"
+              }
+            ]
+          }
+        ],
+        content: [
+          {
+            "type": "p",
+            "children": [
+              {
+                  "text": "A simple paragraph."
+              },
+            ]
+          }
+        ],
+        select: "one"
+      },
+      status: 'draft',
+      createdAt: '2022-11-29T17:28:21.644Z',
+      updatedAt: '2022-11-29T17:28:21.644Z'
+    }
+    const fields: Field[] = [
+      {
+        name: 'title',
+        type: 'text',
+        localized: true,
+      },
+      // select not supported yet
+      {
+        name: 'select',
+        type: 'select',
+        localized: true,
+        options: [
+          'one',
+          'two'
+        ]
+      },
+      {
+        name: 'groupField',
+        type: 'group',
+        localized: true,
+        fields: [
+          {
+            admin: {
+             elements: [
+               "link",
+             ],
+             leaves: [
+               "bold",
+               "italic",
+               "underline",
+             ],
+            },
+            name: 'title',
+            type: 'richText',
+          },
+          {
+            name: 'content',
+            type: 'richText',
+          },
+          // select not supported yet
+          {
+            name: 'select',
+            type: 'select',
             options: [
               'one',
               'two'
@@ -424,6 +555,177 @@ describe("fn: buildCrowdinHtmlObject", () => {
     expect(buildCrowdinHtmlObject({ doc, fields })).toEqual(expected)
   })
 
+  it ("includes localized fields nested in an array with a localization setting on the array field", () => {
+    const doc = {
+      id: '638641358b1a140462752076',
+      title: 'Test Policy created with title',
+      arrayField: [
+        {
+          title: [
+            {
+              "type": "h1",
+              "children": [
+                {
+                    "text": "A "
+                },
+                {
+                    "text": "test",
+                    "bold": true
+                },
+                {
+                    "text": " rich text value"
+                }
+              ]
+            }
+          ],
+          content: [
+            {
+              "type": "p",
+              "children": [
+                {
+                    "text": "A simple paragraph in the first array item."
+                },
+              ]
+            }
+          ],
+          select: "two",
+          id: "64735620230d57bce946d370"
+        },
+        {
+          title: [
+            {
+              "type": "h1",
+              "children": [
+                {
+                    "text": "A "
+                },
+                {
+                    "text": "test",
+                    "bold": true
+                },
+                {
+                    "text": " rich text value"
+                }
+              ]
+            }
+          ],
+          content: [
+            {
+              "type": "p",
+              "children": [
+                {
+                    "text": "A simple paragraph in the second array item."
+                },
+              ]
+            }
+          ],
+          select: "two",
+          id: "64735621230d57bce946d371"
+        }
+      ],
+      status: 'draft',
+      createdAt: '2022-11-29T17:28:21.644Z',
+      updatedAt: '2022-11-29T17:28:21.644Z'
+    }
+    const fields: Field[] = [
+      {
+        name: 'title',
+        type: 'text',
+        localized: true,
+      },
+      // select not supported yet
+      {
+        name: 'select',
+        type: 'select',
+        localized: true,
+        options: [
+          'one',
+          'two'
+        ]
+      },
+      {
+        name: 'arrayField',
+        type: 'array',
+        localized: true,
+        fields: [
+          {
+            name: 'title',
+            type: 'richText',
+          },
+          {
+            name: 'content',
+            type: 'richText',
+          },
+          {
+            name: 'select',
+            type: 'select',
+            options: [
+              'one',
+              'two'
+            ]
+          },
+        ]
+      },
+    ]
+    const expected = {
+      ['arrayField[0].title']: [
+        {
+          "type": "h1",
+          "children": [
+            {
+                "text": "A "
+            },
+            {
+                "text": "test",
+                "bold": true
+            },
+            {
+                "text": " rich text value"
+            }
+          ]
+        }
+      ],
+      ['arrayField[0].content']: [
+        {
+          "type": "p",
+          "children": [
+            {
+                "text": "A simple paragraph in the first array item."
+            },
+          ]
+        }
+      ],
+      ['arrayField[1].title']: [
+        {
+          "type": "h1",
+          "children": [
+            {
+                "text": "A "
+            },
+            {
+                "text": "test",
+                "bold": true
+            },
+            {
+                "text": " rich text value"
+            }
+          ]
+        }
+      ],
+      ['arrayField[1].content']: [
+        {
+          "type": "p",
+          "children": [
+            {
+                "text": "A simple paragraph in the second array item."
+            },
+          ]
+        }
+      ],
+    }
+    expect(buildCrowdinHtmlObject({ doc, fields })).toEqual(expected)
+  })
+
   it ("includes localized fields within a collapsible field", () => {
     const doc = {
       id: '638641358b1a140462752076',
@@ -533,6 +835,181 @@ describe("fn: buildCrowdinHtmlObject", () => {
               name: 'select',
               type: 'select',
               localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        }],
+      },
+    ]
+    const expected = {
+      ['arrayField[0].title']: [
+        {
+          "type": "h1",
+          "children": [
+            {
+                "text": "A "
+            },
+            {
+                "text": "test",
+                "bold": true
+            },
+            {
+                "text": " rich text value"
+            }
+          ]
+        }
+      ],
+      ['arrayField[0].content']: [
+        {
+          "type": "p",
+          "children": [
+            {
+                "text": "A simple paragraph in the first array item."
+            },
+          ]
+        }
+      ],
+      ['arrayField[1].title']: [
+        {
+          "type": "h1",
+          "children": [
+            {
+                "text": "A "
+            },
+            {
+                "text": "test",
+                "bold": true
+            },
+            {
+                "text": " rich text value"
+            }
+          ]
+        }
+      ],
+      ['arrayField[1].content']: [
+        {
+          "type": "p",
+          "children": [
+            {
+                "text": "A simple paragraph in the second array item."
+            },
+          ]
+        }
+      ],
+    }
+    expect(buildCrowdinHtmlObject({ doc, fields })).toEqual(expected)
+  })
+
+  it ("includes localized fields within a collapsible field with a localization setting on the array field", () => {
+    const doc = {
+      id: '638641358b1a140462752076',
+      title: 'Test Policy created with title',
+      arrayField: [
+        {
+          title: [
+            {
+              "type": "h1",
+              "children": [
+                {
+                    "text": "A "
+                },
+                {
+                    "text": "test",
+                    "bold": true
+                },
+                {
+                    "text": " rich text value"
+                }
+              ]
+            }
+          ],
+          content: [
+            {
+              "type": "p",
+              "children": [
+                {
+                    "text": "A simple paragraph in the first array item."
+                },
+              ]
+            }
+          ],
+          select: "two",
+          id: "64735620230d57bce946d370"
+        },
+        {
+          title: [
+            {
+              "type": "h1",
+              "children": [
+                {
+                    "text": "A "
+                },
+                {
+                    "text": "test",
+                    "bold": true
+                },
+                {
+                    "text": " rich text value"
+                }
+              ]
+            }
+          ],
+          content: [
+            {
+              "type": "p",
+              "children": [
+                {
+                    "text": "A simple paragraph in the second array item."
+                },
+              ]
+            }
+          ],
+          select: "two",
+          id: "64735621230d57bce946d371"
+        }
+      ],
+      status: 'draft',
+      createdAt: '2022-11-29T17:28:21.644Z',
+      updatedAt: '2022-11-29T17:28:21.644Z'
+    }
+    const fields: Field[] = [
+      {
+        name: 'title',
+        type: 'text',
+        localized: true,
+      },
+      // select not supported yet
+      {
+        name: 'select',
+        type: 'select',
+        localized: true,
+        options: [
+          'one',
+          'two'
+        ]
+      },
+      {
+        label: "Array fields",
+        type: "collapsible",
+        fields: [{
+          name: 'arrayField',
+          type: 'array',
+          localized: true,
+          fields: [
+            {
+              name: 'title',
+              type: 'richText',
+            },
+            {
+              name: 'content',
+              type: 'richText',
+            },
+            {
+              name: 'select',
+              type: 'select',
               options: [
                 'one',
                 'two'

--- a/src/utilities/buildJsonCrowdinObject.spec.ts
+++ b/src/utilities/buildJsonCrowdinObject.spec.ts
@@ -26,7 +26,7 @@ describe("fn: buildCrowdinJsonObject", () => {
     const expected = {
       title: 'Test Policy created with title',
     }
-    expect(buildCrowdinJsonObject(doc, localizedFields)).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
 
   it ("includes localized fields", () => {
@@ -54,7 +54,7 @@ describe("fn: buildCrowdinJsonObject", () => {
       title: 'Test Policy created with title',
       anotherString: 'An example string',
     }
-    expect(buildCrowdinJsonObject(doc, localizedFields)).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
 
   it ("includes localized fields nested in a group", () => {
@@ -121,7 +121,72 @@ describe("fn: buildCrowdinJsonObject", () => {
         text: "Group text field content",
       },
     }
-    expect(buildCrowdinJsonObject(doc, localizedFields)).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
+  })
+
+  it ("includes localized fields nested in a group with a localization setting on the group field", () => {
+    const doc = {
+      id: '638641358b1a140462752076',
+      title: 'Test Policy created with title',
+      groupField: {
+        title: "Group title field content",
+        text: "Group text field content",
+        select: "one"
+      },
+      status: 'draft',
+      createdAt: '2022-11-29T17:28:21.644Z',
+      updatedAt: '2022-11-29T17:28:21.644Z'
+    }
+    const fields: FieldWithName[] = [
+      {
+        name: 'title',
+        type: 'text',
+        localized: true,
+      },
+      // select not supported yet
+      {
+        name: 'select',
+        type: 'select',
+        localized: true,
+        options: [
+          'one',
+          'two'
+        ]
+      },
+      {
+        name: 'groupField',
+        type: 'group',
+        localized: true,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'text',
+            type: 'text',
+          },
+          // select not supported yet
+          {
+            name: 'select',
+            type: 'select',
+            options: [
+              'one',
+              'two'
+            ]
+          },
+        ]
+      },
+    ]
+    const localizedFields = getLocalizedFields({ fields })
+    const expected = {
+      title: 'Test Policy created with title',
+      groupField: {
+        title: "Group title field content",
+        text: "Group text field content",
+      },
+    }
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
 
   it ("includes localized fields nested in an array", () => {
@@ -202,7 +267,86 @@ describe("fn: buildCrowdinJsonObject", () => {
         }
       ],
     }
-    expect(buildCrowdinJsonObject(doc, localizedFields)).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
+  })
+
+  it ("includes localized fields nested in an array with a localization setting on the array field", () => {
+    const doc = {
+      id: '638641358b1a140462752076',
+      title: 'Test Policy created with title',
+      arrayField: [
+        {
+          title: "Array field title content one",
+          text: "Array field text content one",
+          select: "two",
+          id: "64735620230d57bce946d370"
+        },
+        {
+          title: "Array field title content two",
+          text: "Array field text content two",
+          select: "two",
+          id: "64735621230d57bce946d371"
+        }
+      ],
+      status: 'draft',
+      createdAt: '2022-11-29T17:28:21.644Z',
+      updatedAt: '2022-11-29T17:28:21.644Z'
+    }
+    const fields: FieldWithName[] = [
+      {
+        name: 'title',
+        type: 'text',
+        localized: true,
+      },
+      // select not supported yet
+      {
+        name: 'select',
+        type: 'select',
+        localized: true,
+        options: [
+          'one',
+          'two'
+        ]
+      },
+      {
+        name: 'arrayField',
+        type: 'array',
+        localized: true,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'text',
+            type: 'text',
+          },
+          {
+            name: 'select',
+            type: 'select',
+            options: [
+              'one',
+              'two'
+            ]
+          },
+        ]
+      },
+    ]
+    const localizedFields = getLocalizedFields({ fields })
+    const expected = {
+      title: 'Test Policy created with title',
+      arrayField: [
+        {
+          title: "Array field title content one",
+          text: "Array field text content one",
+        },
+        {
+          title: "Array field title content two",
+          text: "Array field text content two",
+        }
+      ],
+    }
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
 
   it ("includes localized fields within a collapsible field", () => {
@@ -287,7 +431,7 @@ describe("fn: buildCrowdinJsonObject", () => {
         }
       ],
     }
-    expect(buildCrowdinJsonObject(doc, localizedFields)).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
 
   it ("includes localized fields and meta @payloadcms/plugin-seo ", () => {
@@ -325,7 +469,7 @@ describe("fn: buildCrowdinJsonObject", () => {
       title: 'Test Policy created with title',
       meta: { title: 'Test Policy created with title | Teamtailor' },
     }
-    expect(buildCrowdinJsonObject(doc, localizedFields)).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
 
   it ("includes localized fields and removes localization keys from meta @payloadcms/plugin-seo ", () => {
@@ -363,7 +507,7 @@ describe("fn: buildCrowdinJsonObject", () => {
       title: 'Test Policy created with title',
       meta: { title: 'Test Policy created with title | Teamtailor' },
     }
-    expect(buildCrowdinJsonObject(doc, localizedFields)).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
 })
 
@@ -487,15 +631,15 @@ describe("fn: buildCrowdinJsonObject - group nested in array", () => {
   }
 
   it('includes group json fields nested inside of array field items', () => {
-    expect(buildCrowdinJsonObject(doc, getLocalizedFields({ fields: Promos.fields, type: 'json'}))).toEqual(expected)
+    expect(buildCrowdinJsonObject({doc, fields:getLocalizedFields({ fields: Promos.fields, type: 'json'})})).toEqual(expected)
   })
 
   it('includes group json fields nested inside of array field items even when getLocalizedFields is run twice', () => {
-    expect(buildCrowdinJsonObject(doc,
-      getLocalizedFields({ 
+    expect(buildCrowdinJsonObject({doc,
+      fields: getLocalizedFields({ 
         fields: getLocalizedFields({ fields: Promos.fields })
       , type: 'json'})
-    )).toEqual(expected)
+      })).toEqual(expected)
   })
 
   /**
@@ -505,33 +649,33 @@ describe("fn: buildCrowdinJsonObject - group nested in array", () => {
    * with non-required empty fields.
    */
   it('can work with an empty document', () => {
-    expect(buildCrowdinJsonObject({},
-      getLocalizedFields({ fields: Promos.fields })
-    )).toEqual({})
+    expect(buildCrowdinJsonObject({doc: {},
+      fields: getLocalizedFields({ fields: Promos.fields })
+    })).toEqual({})
   })
 
   it('can work with an empty array field', () => {
-    expect(buildCrowdinJsonObject({
+    expect(buildCrowdinJsonObject({doc: {
       ...doc,
       ctas: undefined,
     },
-      getLocalizedFields({ fields: Promos.fields })
-    )).toEqual({
+      fields: getLocalizedFields({ fields: Promos.fields })
+    })).toEqual({
       "text": "Get in touch with us or try it out yourself",
       "title": "Experience the magic of our product!"
     })
   })
 
   it('can work with an empty group field in an array', () => {
-    expect(buildCrowdinJsonObject({
+    expect(buildCrowdinJsonObject({doc: {
       ...doc,
       ctas: [
         {},
         {}
       ],
     },
-      getLocalizedFields({ fields: Promos.fields })
-    )).toEqual({
+      fields: getLocalizedFields({ fields: Promos.fields })
+    })).toEqual({
       ctas: [
         {},
         {}

--- a/src/utilities/getLocalizedFields.spec.ts
+++ b/src/utilities/getLocalizedFields.spec.ts
@@ -130,6 +130,70 @@ describe("fn: getLocalizedFields", () => {
       expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
     })
 
+    it ("includes localized fields from an array with a localization setting on the array field", () => {
+      const global: GlobalConfig = {
+        slug: "global",
+        fields: [
+          {
+            name: 'simpleLocalizedField',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'simpleNonLocalizedField',
+            type: 'text',
+          },
+          {
+            name: 'arrayField',
+            type: 'array',
+            localized: true,
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+                
+              },
+              {
+                name: 'text',
+                type: 'text',
+              },
+              {
+                name: 'select',
+                type: 'select',
+                options: [
+                  'one',
+                  'two'
+                ]
+              },
+            ]
+          },
+        ]
+      }
+      const expected = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          localized: true,
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'text',
+              type: 'text',
+            },
+          ]
+        },
+      ]
+      expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
+    })
+
     /**
      * * help ensure no errors during version 0 development
      * * mitigate against errors if a new field type is introduced by Payload CMS
@@ -190,45 +254,42 @@ describe("fn: getLocalizedFields", () => {
     })
 
     it ("includes localized fields from a group field", () => {
-      const global: GlobalConfig = {
-        slug: "global",
-        fields: [
-          {
-            name: 'simpleLocalizedField',
-            type: 'text',
-            localized: true,
-          },
-          {
-            name: 'simpleNonLocalizedField',
-            type: 'text',
-          },
-          {
-            name: 'groupField',
-            type: 'group',
-            fields: [
-              {
-                name: 'simpleLocalizedField',
-                type: 'text',
-                localized: true,
-              },
-              {
-                name: 'simpleNonLocalizedField',
-                type: 'text',
-              },
-              // select fields not supported yet
-              {
-                name: 'text',
-                type: 'select',
-                localized: true,
-                options: [
-                  'one',
-                  'two'
-                ]
-              },
-            ]
-          },
-        ]
-      }
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
       const expected = [
         {
           name: 'simpleLocalizedField',
@@ -247,7 +308,68 @@ describe("fn: getLocalizedFields", () => {
           ]
         },
       ]
-      expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
+      expect(getLocalizedFields({ fields })).toEqual(expected)
+    })
+
+    it ("includes localized fields from a group field with a localization setting on the group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          localized: true,
+          fields: [
+            {
+              name: 'textLocalizedField',
+              type: 'text',
+            },
+            {
+              name: 'richTextLocalizedField',
+              type: 'richText',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      const expected = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          localized: true,
+          fields: [
+            {
+              name: 'textLocalizedField',
+              type: 'text',
+            },
+            {
+              name: 'richTextLocalizedField',
+              type: 'richText',
+            },
+          ]
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual(expected)
     })
 
     /**


### PR DESCRIPTION
From https://payloadcms.com/docs/configuration/localization#field-by-field-localization:

> Enabling localization for field types that support nested fields will automatically create localized "sets" of all fields contained within the field. For example, if you have a page layout using a blocks field type, you have the choice of either localizing the full layout, by enabling localization on the top-level blocks field, or only certain fields within the layout.

Support this scenario.