### PR TITLE
fix(containslocalizedfields): fix logic, add tests

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -39,7 +39,7 @@ export const crowdInSync =
       collections: [
         ...(config.collections || []).map(existingCollection => {
 
-          if (containsLocalizedFields(existingCollection.fields)) {
+          if (containsLocalizedFields({ fields: existingCollection.fields })) {
             const fields = getFields({
               collection: existingCollection,
             })
@@ -71,7 +71,7 @@ export const crowdInSync =
       globals: [
         ...(config.globals || []).map(existingGlobal => {
 
-          if (containsLocalizedFields(existingGlobal.fields)) {
+          if (containsLocalizedFields({ fields: existingGlobal.fields })) {
             const fields = getFields({
               collection: existingGlobal,
             })

--- a/src/utilities/containsLocalizedFields.spec.ts
+++ b/src/utilities/containsLocalizedFields.spec.ts
@@ -1,0 +1,829 @@
+import {CollectionConfig, Field, GlobalConfig } from 'payload/types'
+import { containsLocalizedFields, getLocalizedFields } from '.'
+
+describe("fn: containsLocalizedFields: true tests", () => {
+  describe("basic field type tests", () => {
+    it ("includes localized fields from a group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+    })
+
+    it ("includes localized fields from an array field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'text',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'select',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+    })
+
+    it ("includes localized fields from an array with a localization setting on the array field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          localized: true,
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              
+            },
+            {
+              name: 'text',
+              type: 'text',
+            },
+            {
+              name: 'select',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+    })
+
+    it ("includes localized fields from an array inside a collapsible field where the top-level field group only contains collapsible fields", () => {
+      const fields: Field[] = [
+        {
+          label: "Array fields",
+          type: "collapsible",
+          fields: [{
+            name: 'arrayField',
+            type: 'array',
+            fields: [
+              {
+                name: 'title',
+                type: 'richText',
+                localized: true,
+              },
+              {
+                name: 'content',
+                type: 'richText',
+                localized: true,
+              },
+              {
+                name: 'select',
+                type: 'select',
+                localized: true,
+                options: [
+                  'one',
+                  'two'
+                ]
+              },
+            ]
+          }],
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+    })
+
+    /**
+     * * help ensure no errors during version 0 development
+     * * mitigate against errors if a new field type is introduced by Payload CMS
+     */
+    it ("does not include unrecognized field types", () => {
+      const fields: any[] = [
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'textNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'unknownLocalizedField',
+          type: 'weird',
+          localized: true,
+        },
+        {
+          name: "Unknown Field type",
+          type: 'strange',
+          fields: [
+            {
+              name: 'textLocalizedFieldInCollapsibleField',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'textNonLocalizedFieldInCollapsibleField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'selectLocalizedFieldInCollapsibleField',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+    })
+
+    it ("includes localized fields from a group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+    })
+
+    it ("includes localized fields from a group field with a localization setting on the group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          localized: true,
+          fields: [
+            {
+              name: 'textLocalizedField',
+              type: 'text',
+            },
+            {
+              name: 'richTextLocalizedField',
+              type: 'richText',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+    })
+  })
+
+  it ("includes localized fields from a group field with a localization setting on the group field: localized parent only", () => {
+    const fields: Field[] = [
+      {
+        name: 'groupField',
+        type: 'group',
+        localized: true,
+        fields: [
+          {
+            name: 'textLocalizedField',
+            type: 'text',
+          },
+          {
+            name: 'richTextLocalizedField',
+            type: 'richText',
+          },
+          // select fields not supported yet
+          {
+            name: 'text',
+            type: 'select',
+            options: [
+              'one',
+              'two'
+            ]
+          },
+        ]
+      },
+    ]
+    expect(containsLocalizedFields({ fields })).toEqual(true)
+  })
+
+  describe ("extract rich text localized fields", () => {
+    const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'richText',
+          localized: true,
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'richText',
+              type: 'richText',
+              localized: true,
+            },
+            {
+              name: 'select',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'richText',
+              localized: true,
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(true)
+  })
+  
+  it ("returns nested json fields in a group inside an array", () => {
+    const linkField: Field = {
+      name: 'link',
+      type: 'group',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'href',
+          type: 'text'
+        },
+        {
+          name: 'type',
+          type: 'select',
+          options: [
+            'ctaPrimary',
+            'ctaSecondary'
+          ]
+        }
+      ]
+    }
+    const Promos: CollectionConfig = {
+      slug: 'promos',
+      admin: {
+        defaultColumns: ['title', 'updatedAt'],
+        useAsTitle: 'title',
+        group: "Shared",
+      },
+      access: {
+        read: () => true,
+      },
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'text',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'ctas',
+          type: 'array',
+          minRows: 1,
+          maxRows: 2,
+          fields: [
+            linkField,
+          ]
+        }
+      ]
+    }
+    expect(containsLocalizedFields({ fields: Promos.fields })).toEqual(true)
+  })
+})
+
+describe("fn: containsLocalizedFields: false tests", () => {
+  describe("basic field type tests", () => {
+    it ("includes localized fields from a group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'text',
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+    })
+
+    it ("includes localized fields from an array field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'text',
+              type: 'text',
+            },
+            {
+              name: 'select',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+    })
+
+    it ("includes localized fields from an array with a localization setting on the array field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              
+            },
+            {
+              name: 'text',
+              type: 'text',
+            },
+            {
+              name: 'select',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+    })
+
+    it ("includes localized fields from an array inside a collapsible field where the top-level field group only contains collapsible fields", () => {
+      const fields: Field[] = [
+        {
+          label: "Array fields",
+          type: "collapsible",
+          fields: [{
+            name: 'arrayField',
+            type: 'array',
+            fields: [
+              {
+                name: 'title',
+                type: 'richText',
+              },
+              {
+                name: 'content',
+                type: 'richText',
+              },
+              {
+                name: 'select',
+                type: 'select',
+                options: [
+                  'one',
+                  'two'
+                ]
+              },
+            ]
+          }],
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+    })
+
+    /**
+     * * help ensure no errors during version 0 development
+     * * mitigate against errors if a new field type is introduced by Payload CMS
+     */
+    it ("does not include unrecognized field types", () => {
+      const fields: any[] = [
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'textNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'unknownLocalizedField',
+          type: 'weird',
+          localized: true,
+        },
+        {
+          name: "Unknown Field type",
+          type: 'strange',
+          fields: [
+            {
+              name: 'textLocalizedFieldInCollapsibleField',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'textNonLocalizedFieldInCollapsibleField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'selectLocalizedFieldInCollapsibleField',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+    })
+
+    it ("includes localized fields from a group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'text',
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+    })
+
+    it ("includes localized fields from a group field with a localization setting on the group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'textLocalizedField',
+              type: 'text',
+            },
+            {
+              name: 'richTextLocalizedField',
+              type: 'richText',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+    })
+  })
+
+  describe ("extract rich text localized fields", () => {
+    const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'richText',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'richText',
+              type: 'richText',
+            },
+            {
+              name: 'select',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'richText',
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(containsLocalizedFields({ fields })).toEqual(false)
+  })
+  
+  it ("returns nested json fields in a group inside an array", () => {
+    const linkField: Field = {
+      name: 'link',
+      type: 'group',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+        {
+          name: 'href',
+          type: 'text'
+        },
+        {
+          name: 'type',
+          type: 'select',
+          options: [
+            'ctaPrimary',
+            'ctaSecondary'
+          ]
+        }
+      ]
+    }
+    const Promos: CollectionConfig = {
+      slug: 'promos',
+      admin: {
+        defaultColumns: ['title', 'updatedAt'],
+        useAsTitle: 'title',
+        group: "Shared",
+      },
+      access: {
+        read: () => true,
+      },
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+        {
+          name: 'text',
+          type: 'text',
+        },
+        {
+          name: 'ctas',
+          type: 'array',
+          minRows: 1,
+          maxRows: 2,
+          fields: [
+            linkField,
+          ]
+        }
+      ]
+    }
+    expect(containsLocalizedFields({ fields: Promos.fields })).toEqual(false)
+  })
+})

--- a/src/utilities/getLocalizedFields.spec.ts
+++ b/src/utilities/getLocalizedFields.spec.ts
@@ -194,6 +194,57 @@ describe("fn: getLocalizedFields", () => {
       expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
     })
 
+    it ("includes localized fields from an array inside a collapsible field where the top-level field group only contains collapsible fields", () => {
+      const fields: Field[] = [
+        {
+          label: "Array fields",
+          type: "collapsible",
+          fields: [{
+            name: 'arrayField',
+            type: 'array',
+            fields: [
+              {
+                name: 'title',
+                type: 'richText',
+                localized: true,
+              },
+              {
+                name: 'content',
+                type: 'richText',
+                localized: true,
+              },
+              {
+                name: 'select',
+                type: 'select',
+                localized: true,
+                options: [
+                  'one',
+                  'two'
+                ]
+              },
+            ]
+          }],
+        },
+      ]
+      const expected = [{
+        name: 'arrayField',
+        type: 'array',
+        fields: [
+          {
+            name: 'title',
+            type: 'richText',
+            localized: true,
+          },
+          {
+            name: 'content',
+            type: 'richText',
+            localized: true,
+          },
+        ]
+      }]
+      expect(getLocalizedFields({ fields })).toEqual(expected)
+    })
+
     /**
      * * help ensure no errors during version 0 development
      * * mitigate against errors if a new field type is introduced by Payload CMS
@@ -566,7 +617,7 @@ describe("fn: getLocalizedFields", () => {
     expect(getLocalizedFields({ fields: global.fields, type: 'html'})).toEqual(expected)
   })
   
-  it ("returns an nested json fields in a group inside an array", () => {
+  it ("returns nested json fields in a group inside an array", () => {
     const linkField: Field = {
       name: 'link',
       type: 'group',
@@ -655,5 +706,261 @@ describe("fn: getLocalizedFields", () => {
     ]
     const jsonFields = getLocalizedFields({ fields: Promos.fields, type: 'json'})
     expect(jsonFields).toEqual(expected)
+  })
+
+  describe("empty tests", () => {
+    it ("ignore non-localized group field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            {
+              name: 'simpleLocalizedField',
+              type: 'text',
+            },
+            {
+              name: 'simpleNonLocalizedField',
+              type: 'text',
+            },
+            // select fields not supported yet
+            {
+              name: 'text',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      
+      expect(getLocalizedFields({ fields })).toEqual([])
+    })
+
+    it ("ignore non-localized array field", () => {
+      const fields: Field[] = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'simpleNonLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'arrayField',
+          type: 'array',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+            },
+            {
+              name: 'text',
+              type: 'text',
+            },
+            {
+              name: 'select',
+              type: 'select',
+              localized: true,
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual([])
+    })
+
+    it ("ignore non-localized fields from an array inside a collapsible field where the top-level field group only contains collapsible fields", () => {
+      const fields: Field[] = [
+        {
+          label: "Array fields",
+          type: "collapsible",
+          fields: [{
+            name: 'arrayField',
+            type: 'array',
+            fields: [
+              {
+                name: 'title',
+                type: 'richText',
+              },
+              {
+                name: 'content',
+                type: 'richText',
+              },
+              {
+                name: 'select',
+                type: 'select',
+                options: [
+                  'one',
+                  'two'
+                ]
+              },
+            ]
+          }],
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual([])
+    })
+
+    /**
+     * * help ensure no errors during version 0 development
+     * * mitigate against errors if a new field type is introduced by Payload CMS
+     */
+    it ("does not include unrecognized field types", () => {
+      const global: any = {
+        slug: "global",
+        fields: [
+          {
+            name: 'textLocalizedField',
+            type: 'text',
+          },
+          {
+            name: 'textNonLocalizedField',
+            type: 'text',
+          },
+          {
+            name: 'unknownLocalizedField',
+            type: 'weird',
+            localized: true,
+          },
+          {
+            name: "Unknown Field type",
+            type: 'strange',
+            fields: [
+              {
+                name: 'textLocalizedFieldInCollapsibleField',
+                type: 'text',
+                localized: true,
+              },
+              {
+                name: 'textNonLocalizedFieldInCollapsibleField',
+                type: 'text',
+              },
+              // select fields not supported yet
+              {
+                name: 'selectLocalizedFieldInCollapsibleField',
+                type: 'select',
+                localized: true,
+                options: [
+                  'one',
+                  'two'
+                ]
+              },
+            ]
+          },
+        ]
+      }
+      expect(getLocalizedFields({ fields: global.fields })).toEqual([])
+    })
+
+    /**
+     * blocks not supported yet
+    it ("includes localized fields from a blocks field", () => {
+      const TestBlock: Block = {
+        slug: 'text',
+        imageAltText: 'Text',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'text',
+            type: 'richText',
+            localized: true,
+          },
+          {
+            name: 'select',
+            type: 'select',
+            localized: true,
+            options: [
+              'one',
+              'two'
+            ]
+          },
+        ]
+      }
+      const TestBlockLocalizedFieldsOnly: Block = {
+        slug: 'text',
+        imageAltText: 'Text',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'text',
+            type: 'richText',
+            localized: true,
+          },
+        ]
+      }
+      const global: GlobalConfig = {
+        slug: "global",
+        fields: [
+          {
+            name: 'simpleLocalizedField',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'simpleNonLocalizedField',
+            type: 'text',
+          },
+          {
+            name: 'blocksField',
+            type: 'blocks',
+            blocks: [
+              TestBlock
+            ]
+          },
+        ]
+      }
+      const expected = [
+        {
+          name: 'simpleLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'blocksField',
+          type: 'blocks',
+          blocks: [
+            {
+              fields: [
+                {
+                  name: 'title',
+                  type: 'text',
+                  localized: true,
+                },
+                {
+                  name: 'text',
+                  type: 'richText',
+                  localized: true,
+                },
+              ]
+            }
+          ]
+        },
+      ]
+      expect(getLocalizedFields(global.fields)).toEqual(expected)
+    })
+    */
   })
 })

--- a/src/utilities/index.spec.ts
+++ b/src/utilities/index.spec.ts
@@ -18,7 +18,7 @@ describe("Function: containsLocalizedFields", () => {
         },
       ],
     }
-    expect(containsLocalizedFields(global.fields)).toBe(true)
+    expect(containsLocalizedFields({ fields: global.fields })).toBe(true)
   })
 
   it("detects localized fields in a group field", () => {
@@ -42,7 +42,7 @@ describe("Function: containsLocalizedFields", () => {
         },
       ],
     }
-    expect(containsLocalizedFields(global.fields)).toBe(true)
+    expect(containsLocalizedFields({ fields: global.fields})).toBe(true)
   })
 
   it("detects localized fields in an array field", () => {
@@ -66,52 +66,7 @@ describe("Function: containsLocalizedFields", () => {
         },
       ],
     }
-    expect(containsLocalizedFields(global.fields)).toBe(true)
-  })
-
-  it("detects localized fields in a blocks field", () => {
-    const TestBlock: Block = {
-      slug: 'text',
-      imageAltText: 'Text',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          localized: true,
-        },
-        {
-          name: 'text',
-          type: 'richText',
-          localized: true,
-        },
-        {
-          name: 'select',
-          type: 'select',
-          localized: true,
-          options: [
-            'one',
-            'two'
-          ]
-        },
-      ]
-    }
-    const global: GlobalConfig = {
-      slug: "global",
-      fields: [
-        {
-          name: 'simpleNonLocalizedField',
-          type: 'text',
-        },
-        {
-          name: 'blocksField',
-          type: 'blocks',
-          blocks: [
-            TestBlock
-          ]
-        },
-      ],
-    }
-    expect(containsLocalizedFields(global.fields)).toBe(true)
+    expect(containsLocalizedFields({ fields: global.fields })).toBe(true)
   })
 
   it("returns false if no localized fields in a blocks field", () => {
@@ -153,7 +108,7 @@ describe("Function: containsLocalizedFields", () => {
         },
       ],
     }
-    expect(containsLocalizedFields(global.fields)).toBe(false)
+    expect(containsLocalizedFields({ fields: global.fields })).toBe(false)
   })
 })
 


### PR DESCRIPTION
`containsLocalizedFields` cannot detect localized fields in a [collapsible field](https://payloadcms.com/docs/fields/collapsible). Fix.

## Details

`containsLocalizedFields` is used to determine whether or not to add Payload CrowdIn Sync functionality to a collection or global. Following changes that add support for additional collection/global configurations (https://github.com/thompsonsj/payload-crowdin-sync/pull/18 and https://github.com/thompsonsj/payload-crowdin-sync/pull/20), this function is unable to keep up with the changes.

`getLocalizedFields` is becoming the most important function in this plugin, and `containsLocalizedFields` is refactored to use it. In this way, we have a central place to define logic to check scenarios such as:

- a `localized: true` setting on a field with nested fields in order to add localiztion to all nested fields; and
- support for `collapsible` fields as well as `group`, `array` and eventually: `blocks`.

In order to use `getLocalizedFields`, changes are made to ensure this function returns an empty array if no localized fields are found. For example, before the changes made here, a `group` field with no localized nested fields would return:

```ts
{
  name: 'groupField',
  type: 'group',
  fields: []
}
```

Now `getLocalizedFields` uses `containsLocalizedFields` to check whether or not to include a `group` or an `array`. In turn, `containsLocalizedFields` uses `getLocalizedFields` to perform the check effectively.

Todo: add tests and support for the `blocks` field.