### PR TITLE
feat(utilities): textarea field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
-# WIP 1 June 2023
+# WIP 8 June 2023
 
 This plugin is currently being refactored. Although the logic works, it was extracted from a Payload CMS install and needs work to decouple logic from that installation.
 
 Features:
 
-- [x] Support localized `text` fields. Combine text fields into a single json file on CrowdIn called `fields.json`.
+- [x] Support localized `text` and `textarea` fields. Combine text and textarea fields into a single json file on CrowdIn called `fields.json`.
 - [x] Support localized `richText` fields. Store each `richText` field as HTML (converted from Slate JSON) on CrowdIn with a filename corresponding to the field name.
 - [x] Store CrowdIn files in an appropriate data structure.
 - [ ] Support **sending localized fields to CrowdIn** for the following Payload fields (recursive - can go as deep as necessary):
   - [x] `group`
   - [x] `array`
+  - [x] `collapsible`
   - [ ] `blocks`
 - Improve testing so that it does not require a local server. See [Notes on the current test suite](#notes-on-the-current-test-suite).
 - [ ] Support **updating localized fields from CrowdIn** for the following Payload fields. Note that this will require effective required field detection to avoid update errors. See `getLocalizedRequiredFields`.
   - [ ] `group`
   - [ ] `array`
+  - [ ] `collapsible`
   - [ ] `blocks`
 - [ ] Add UI for syncing translations (currently done with URLs added to `server.ts` on the Payload installation).
 - [ ] Add option to make localized fields read-only in other locales (CrowdIn mangaes these fields).

--- a/src/utilities/buildJsonCrowdinObject.spec.ts
+++ b/src/utilities/buildJsonCrowdinObject.spec.ts
@@ -32,8 +32,9 @@ describe("fn: buildCrowdinJsonObject", () => {
   it ("includes localized fields", () => {
     const doc = {
       id: '638641358b1a140462752076',
-      title: 'Test Policy created with title',
-      anotherString: 'An example string',
+      title: 'Text value',
+      anotherString: 'Another text value',
+      description: 'A textarea value.\nWith a new line.',
       status: 'draft',
       createdAt: '2022-11-29T17:28:21.644Z',
       updatedAt: '2022-11-29T17:28:21.644Z'
@@ -48,11 +49,17 @@ describe("fn: buildCrowdinJsonObject", () => {
         name: 'anotherString',
         type: 'text',
         localized: true,
+      },
+      {
+        name: 'description',
+        type: 'textarea',
+        localized: true,
       }
     ]
     const expected = {
-      title: 'Test Policy created with title',
-      anotherString: 'An example string',
+      title: 'Text value',
+      anotherString: 'Another text value',
+      description: 'A textarea value.\nWith a new line.',
     }
     expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })
@@ -64,6 +71,7 @@ describe("fn: buildCrowdinJsonObject", () => {
       groupField: {
         title: "Group title field content",
         text: "Group text field content",
+        description: 'A textarea value.\nWith a new line.',
         select: "one"
       },
       status: 'draft',
@@ -100,6 +108,11 @@ describe("fn: buildCrowdinJsonObject", () => {
             type: 'text',
             localized: true,
           },
+          {
+            name: 'description',
+            type: 'textarea',
+            localized: true,
+          },
           // select not supported yet
           {
             name: 'select',
@@ -119,6 +132,7 @@ describe("fn: buildCrowdinJsonObject", () => {
       groupField: {
         title: "Group title field content",
         text: "Group text field content",
+        description: 'A textarea value.\nWith a new line.',
       },
     }
     expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
@@ -439,7 +453,10 @@ describe("fn: buildCrowdinJsonObject", () => {
       id: '638641358b1a140462752076',
       title: 'Test Policy created with title',
       status: 'draft',
-      meta: { title: 'Test Policy created with title | Teamtailor' },
+      meta: {
+        title: 'Meta title value',
+        description: 'Meta description value.\nCan contain new lines.',
+      },
       createdAt: '2022-11-29T17:28:21.644Z',
       updatedAt: '2022-11-29T17:28:21.644Z'
     }
@@ -461,13 +478,21 @@ describe("fn: buildCrowdinJsonObject", () => {
             admin: {
               components: {}
             }
+          },
+          {
+            name: "description",
+            type: "textarea",
+            localized: true,
+            admin: {
+              components: {}
+            }
           }
         ]
       }
     ]
     const expected = {
       title: 'Test Policy created with title',
-      meta: { title: 'Test Policy created with title | Teamtailor' },
+      meta: { title: 'Meta title value', description: 'Meta description value.\nCan contain new lines.', },
     }
     expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
   })

--- a/src/utilities/getLocalizedFields.spec.ts
+++ b/src/utilities/getLocalizedFields.spec.ts
@@ -2,179 +2,181 @@ import {CollectionConfig, Field, GlobalConfig } from 'payload/types'
 import { getLocalizedFields } from '.'
 
 describe("fn: getLocalizedFields", () => {
-  describe("basic field type tests", () => {
-    it ("includes localized fields from a group field", () => {
-      const global: GlobalConfig = {
-        slug: "global",
-        fields: [
-          {
-            name: 'simpleLocalizedField',
-            type: 'text',
-            localized: true,
-          },
-          {
-            name: 'simpleNonLocalizedField',
-            type: 'text',
-          },
-          {
-            name: 'groupField',
-            type: 'group',
-            fields: [
-              {
-                name: 'simpleLocalizedField',
-                type: 'text',
-                localized: true,
-              },
-              {
-                name: 'simpleNonLocalizedField',
-                type: 'text',
-              },
-              // select fields not supported yet
-              {
-                name: 'text',
-                type: 'select',
-                localized: true,
-                options: [
-                  'one',
-                  'two'
-                ]
-              },
-            ]
-          },
-        ]
-      }
-      const expected = [
+  describe("basic field types", () => {
+    it("includes a text field", () => {
+      const fields: Field[] = [
         {
-          name: 'simpleLocalizedField',
+          name: 'textLocalizedField',
           type: 'text',
           localized: true,
         },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual(fields)
+    })
+
+    it("includes a richText field", () => {
+      const fields: Field[] = [
+        {
+          name: 'richTextLocalizedField',
+          type: 'richText',
+          localized: true,
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual(fields)
+    })
+
+    it("includes a textarea field", () => {
+      const fields: Field[] = [
+        {
+          name: 'textareaLocalizedField',
+          type: 'textarea',
+          localized: true,
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual(fields)
+    })
+  })
+
+  describe("include fields from groups and arrays", () => {
+    const mixedFieldCollection: Field[] = [
+      {
+        name: 'textLocalizedField',
+        type: 'text',
+        localized: true,
+      },
+      {
+        name: 'textNonLocalizedField',
+        type: 'text',
+      },
+      {
+        name: 'richTextLocalizedField',
+        type: 'richText',
+        localized: true,
+      },
+      {
+        name: 'richTextNonLocalizedField',
+        type: 'richText',
+      },
+      {
+        name: 'textareaLocalizedField',
+        type: 'text',
+        localized: true,
+      },
+      {
+        name: 'textareaNonLocalizedField',
+        type: 'text',
+      },
+      // select fields not supported yet
+      {
+        name: 'text',
+        type: 'select',
+        localized: true,
+        options: [
+          'one',
+          'two'
+        ]
+      },
+    ]
+
+    const localizedFieldCollection: Field[] = [
+      {
+        name: 'textLocalizedField',
+        type: 'text',
+        localized: true,
+      },
+      {
+        name: 'richTextLocalizedField',
+        type: 'richText',
+        localized: true,
+      },
+      {
+        name: 'textareaLocalizedField',
+        type: 'text',
+        localized: true,
+      },
+    ]
+
+    it ("includes localized fields from a group field", () => {
+      const fields: Field[] = [
+        ...mixedFieldCollection,
         {
           name: 'groupField',
           type: 'group',
           fields: [
-            {
-              name: 'simpleLocalizedField',
-              type: 'text',
-              localized: true,
-            },
+            ...mixedFieldCollection,
           ]
         },
       ]
-      expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
+      const expected = [
+        ...localizedFieldCollection,
+        {
+          name: 'groupField',
+          type: 'group',
+          fields: [
+            ...localizedFieldCollection,
+          ]
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual(expected)
     })
 
     it ("includes localized fields from an array field", () => {
-      const global: GlobalConfig = {
-        slug: "global",
-        fields: [
-          {
-            name: 'simpleLocalizedField',
-            type: 'text',
-            localized: true,
-          },
-          {
-            name: 'simpleNonLocalizedField',
-            type: 'text',
-          },
-          {
-            name: 'arrayField',
-            type: 'array',
-            fields: [
-              {
-                name: 'title',
-                type: 'text',
-                localized: true,
-              },
-              {
-                name: 'text',
-                type: 'text',
-                localized: true,
-              },
-              {
-                name: 'select',
-                type: 'select',
-                localized: true,
-                options: [
-                  'one',
-                  'two'
-                ]
-              },
-            ]
-          },
-        ]
-      }
-      const expected = [
-        {
-          name: 'simpleLocalizedField',
-          type: 'text',
-          localized: true,
-        },
+      const fields: Field[] = [
+        ...mixedFieldCollection,
         {
           name: 'arrayField',
           type: 'array',
           fields: [
-            {
-              name: 'title',
-              type: 'text',
-              localized: true,
-            },
-            {
-              name: 'text',
-              type: 'text',
-              localized: true,
-            },
+            ...mixedFieldCollection,
           ]
         },
       ]
-      expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
+      const expected = [
+        ...localizedFieldCollection,
+        {
+          name: 'arrayField',
+          type: 'array',
+          fields: [
+            ...localizedFieldCollection,
+          ]
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual(expected)
     })
 
     it ("includes localized fields from an array with a localization setting on the array field", () => {
-      const global: GlobalConfig = {
-        slug: "global",
-        fields: [
-          {
-            name: 'simpleLocalizedField',
-            type: 'text',
-            localized: true,
-          },
-          {
-            name: 'simpleNonLocalizedField',
-            type: 'text',
-          },
-          {
-            name: 'arrayField',
-            type: 'array',
-            localized: true,
-            fields: [
-              {
-                name: 'title',
-                type: 'text',
-                
-              },
-              {
-                name: 'text',
-                type: 'text',
-              },
-              {
-                name: 'select',
-                type: 'select',
-                options: [
-                  'one',
-                  'two'
-                ]
-              },
-            ]
-          },
-        ]
-      }
-      const expected = [
+      const fields: Field[] = [
+        ...mixedFieldCollection,
         {
-          name: 'simpleLocalizedField',
-          type: 'text',
+          name: 'arrayField',
+          type: 'array',
           localized: true,
+          fields: [
+            {
+              name: 'title',
+              type: 'text',  
+            },
+            {
+              name: 'text',
+              type: 'text',
+            },
+            {
+              name: 'textarea',
+              type: 'textarea',
+            },
+            {
+              name: 'select',
+              type: 'select',
+              options: [
+                'one',
+                'two'
+              ]
+            },
+          ]
         },
+      ]
+      const expected = [
+        ...localizedFieldCollection,
         {
           name: 'arrayField',
           type: 'array',
@@ -188,10 +190,14 @@ describe("fn: getLocalizedFields", () => {
               name: 'text',
               type: 'text',
             },
+            {
+              name: 'textarea',
+              type: 'textarea',
+            },
           ]
         },
       ]
-      expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
+      expect(getLocalizedFields({ fields })).toEqual(expected)
     })
 
     it ("includes localized fields from an array inside a collapsible field where the top-level field group only contains collapsible fields", () => {
@@ -203,25 +209,7 @@ describe("fn: getLocalizedFields", () => {
             name: 'arrayField',
             type: 'array',
             fields: [
-              {
-                name: 'title',
-                type: 'richText',
-                localized: true,
-              },
-              {
-                name: 'content',
-                type: 'richText',
-                localized: true,
-              },
-              {
-                name: 'select',
-                type: 'select',
-                localized: true,
-                options: [
-                  'one',
-                  'two'
-                ]
-              },
+              ...mixedFieldCollection,
             ]
           }],
         },
@@ -230,16 +218,7 @@ describe("fn: getLocalizedFields", () => {
         name: 'arrayField',
         type: 'array',
         fields: [
-          {
-            name: 'title',
-            type: 'richText',
-            localized: true,
-          },
-          {
-            name: 'content',
-            type: 'richText',
-            localized: true,
-          },
+          ...localizedFieldCollection,
         ]
       }]
       expect(getLocalizedFields({ fields })).toEqual(expected)
@@ -304,87 +283,25 @@ describe("fn: getLocalizedFields", () => {
       expect(getLocalizedFields({ fields: global.fields })).toEqual(expected)
     })
 
-    it ("includes localized fields from a group field", () => {
-      const fields: Field[] = [
-        {
-          name: 'simpleLocalizedField',
-          type: 'text',
-          localized: true,
-        },
-        {
-          name: 'simpleNonLocalizedField',
-          type: 'text',
-        },
-        {
-          name: 'groupField',
-          type: 'group',
-          fields: [
-            {
-              name: 'simpleLocalizedField',
-              type: 'text',
-              localized: true,
-            },
-            {
-              name: 'simpleNonLocalizedField',
-              type: 'text',
-            },
-            // select fields not supported yet
-            {
-              name: 'text',
-              type: 'select',
-              localized: true,
-              options: [
-                'one',
-                'two'
-              ]
-            },
-          ]
-        },
-      ]
-      const expected = [
-        {
-          name: 'simpleLocalizedField',
-          type: 'text',
-          localized: true,
-        },
-        {
-          name: 'groupField',
-          type: 'group',
-          fields: [
-            {
-              name: 'simpleLocalizedField',
-              type: 'text',
-              localized: true,
-            },
-          ]
-        },
-      ]
-      expect(getLocalizedFields({ fields })).toEqual(expected)
-    })
-
     it ("includes localized fields from a group field with a localization setting on the group field", () => {
       const fields: Field[] = [
-        {
-          name: 'simpleLocalizedField',
-          type: 'text',
-          localized: true,
-        },
-        {
-          name: 'simpleNonLocalizedField',
-          type: 'text',
-        },
+        ...mixedFieldCollection,
         {
           name: 'groupField',
           type: 'group',
           localized: true,
           fields: [
             {
-              name: 'textLocalizedField',
+              name: 'text',
               type: 'text',
             },
             {
-              name: 'richTextLocalizedField',
+              name: 'richText',
               type: 'richText',
+            },
+            {
+              name: 'textarea',
+              type: 'textarea',
             },
             // select fields not supported yet
             {
@@ -399,23 +316,23 @@ describe("fn: getLocalizedFields", () => {
         },
       ]
       const expected = [
-        {
-          name: 'simpleLocalizedField',
-          type: 'text',
-          localized: true,
-        },
+        ...localizedFieldCollection,
         {
           name: 'groupField',
           type: 'group',
           localized: true,
           fields: [
             {
-              name: 'textLocalizedField',
+              name: 'text',
               type: 'text',
             },
             {
-              name: 'richTextLocalizedField',
+              name: 'richText',
               type: 'richText',
+            },
+            {
+              name: 'textarea',
+              type: 'textarea',
             },
           ]
         },

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -7,7 +7,8 @@ import { isEmpty, merge } from "lodash"
 
 const localizedFieldTypes = [
   'richText',
-  'text'
+  'text',
+  'textarea',
 ]
 
 const nestedFieldTypes = [


### PR DESCRIPTION
Add support for `textarea` fields. Combine `text` and `textarea` fields into the same `fields.json` file.