### PR TITLE
fix(plugin-seo): return empty if localized fields are only seo

### DIFF
--- a/src/utilities/getLocalizedFields.spec.ts
+++ b/src/utilities/getLocalizedFields.spec.ts
@@ -880,4 +880,78 @@ describe("fn: getLocalizedFields", () => {
     })
     */
   })
+
+  /**
+   * @see https://github.com/payloadcms/plugin-seo
+   * 
+   * payloadcms/plugin-seo adds localized fields.
+   * If there are no other localized fields, we don't
+   * want to submit to CrowdIn.
+   */
+  describe("payloadcms/plugin-seo tests", () => {
+    const seoFields: Field[] = [
+      {
+        "name": "meta",
+        "label": "SEO",
+        "type": "group",
+        "fields": [
+          /**{
+            "name": "overview",
+            "label": "Overview",
+            "type": "ui",
+            "admin": {
+              "components": {}
+            }
+          },*/
+          {
+            "name": "title",
+            "type": "text",
+            "localized": true,
+            "admin": {
+              "components": {}
+            }
+          },
+          {
+            "name": "description",
+            "type": "textarea",
+            "localized": true,
+            "admin": {
+              "components": {}
+            }
+          },
+          /**{
+            "name": "preview",
+            "label": "Preview",
+            "type": "ui",
+            "admin": {
+              "components": {}
+            }
+          }**/
+        ]
+      }
+    ]
+
+    it("excludes payloadcms/plugin-seo localized fields if there are no localized fields on the collection/global", () => {
+      const nonLocalizedFieldCollection: Field[] = [
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+        },
+        {
+          name: 'richTextLocalizedField',
+          type: 'richText',
+        },
+        {
+          name: 'textareaLocalizedField',
+          type: 'text',
+        },
+      ]
+
+      const fields: Field[] = [
+        ...nonLocalizedFieldCollection,
+        ...seoFields,
+      ]
+      expect(getLocalizedFields({ fields })).toEqual([])
+    })
+  })
 })

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -3,7 +3,7 @@ import deepEqual from 'deep-equal'
 import { FieldWithName } from '../types'
 import { slateToHtml, payloadSlateToDomConfig } from 'slate-serializers'
 import type { Descendant } from 'slate'
-import { isEmpty, merge } from "lodash"
+import { get, isEmpty, merge } from "lodash"
 
 const localizedFieldTypes = [
   'richText',
@@ -20,6 +20,26 @@ const nestedFieldTypes = [
 export const containsNestedFields = (field: Field) => nestedFieldTypes.includes(field.type)
 
 export const getLocalizedFields = ({
+  fields,
+  type,
+  localizedParent = false,
+}: {
+  fields: Field[],
+  type?: 'json' | 'html',
+  localizedParent?: boolean
+}): any[] => {
+  const localizedFields = getLocalizedFieldsRecursive({
+    fields,
+    type,
+    localizedParent,
+  })
+  if (localizedFields.length === 1 && get(localizedFields[0], 'name') === 'meta') {
+    return []
+  }
+  return localizedFields
+}
+
+export const getLocalizedFieldsRecursive = ({
   fields,
   type,
   localizedParent = false,


### PR DESCRIPTION
This is not how this should be done.

It is an interim fix while I figure out how to handle a scenario where there are no localized fields on a collection except the localized fields added by https://github.com/payloadcms/plugin-seo.

By default, `payload-crowdin-sync` detects localized fields on a collection or global, and then syncs with crowdIn automatically. If SEO is enabled on a collection or global without localized fields, it will start syncing with crowdIn for the meta fields only.

This makes the following scenario likely: https://github.com/thompsonsj/payload-crowdin-sync/issues/29.

To keep this default behaviour, I am implementing this measure. This should be removed once https://github.com/thompsonsj/payload-crowdin-sync/issues/29 is resolved because only localized SEO fields is a reasonable scenario (e.g. a gallery of images or a collection that contains fields unsupported by the plugin).