### PR TITLE
fix(api): invalid name error when more than 10 files

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -77,14 +77,25 @@ export class crowdinAPIService {
       fileData,
       fileType,
     })
-    const file = await this.crowdin.sourceFilesApi.createFile(projectId, {
+    const options = {
       name: `${name}.${fileType}`,
       title: name,
       storageId: storageId,
       directoryId: directoryId,
       type: fileType
-    })
-    return file
+    }
+    try {
+      const file = await this.crowdin.sourceFilesApi.createFile(projectId, {
+        name: `${name}.${fileType}`,
+        title: name,
+        storageId: storageId,
+        directoryId: directoryId,
+        type: fileType
+      })
+      return file
+    } catch (error) {
+      console.error(error, options)
+    }
   }
 
   async updateFile({

--- a/src/api/payload.ts
+++ b/src/api/payload.ts
@@ -160,6 +160,7 @@ interface IupdateTranslation extends ApiObjects {
 export async function getCrowdinFiles(crowdinArticleDirectoryId: number, payload: Payload): Promise<any> {
   const result = await payload.find({
     collection: "crowdin-files",
+    limit: 9999,
     where: {
       crowdinArticleDirectory: {
         equals: crowdinArticleDirectoryId,
@@ -250,25 +251,27 @@ export async function payloadCreateCrowdInFile({
   }}*/
 
   // Store result on Payload CMS
-  const payloadCrowdInFile = await payload.create({
-    collection: 'crowdin-files', // required
-    data: { // required
-      title: crowdInFile.data.name,
-      field: name,
-      crowdinArticleDirectory: articleDirectory.id,
-      createdAt: crowdInFile.data.createdAt,
-      updatedAt: crowdInFile.data.updatedAt,
-      originalId: crowdInFile.data.id,
-      projectId: crowdInFile.data.projectId,
-      directoryId: crowdInFile.data.directoryId,
-      revisionId: crowdInFile.data.revisionId,
-      name: crowdInFile.data.name,
-      type: crowdInFile.data.type,
-      path: crowdInFile.data.path,
-    },
-  })
+  if (crowdInFile) {
+    const payloadCrowdInFile = await payload.create({
+      collection: 'crowdin-files', // required
+      data: { // required
+        title: crowdInFile.data.name,
+        field: name,
+        crowdinArticleDirectory: articleDirectory.id,
+        createdAt: crowdInFile.data.createdAt,
+        updatedAt: crowdInFile.data.updatedAt,
+        originalId: crowdInFile.data.id,
+        projectId: crowdInFile.data.projectId,
+        directoryId: crowdInFile.data.directoryId,
+        revisionId: crowdInFile.data.revisionId,
+        name: crowdInFile.data.name,
+        type: crowdInFile.data.type,
+        path: crowdInFile.data.path,
+      },
+    })
 
-  return payloadCrowdInFile
+    return payloadCrowdInFile
+  }
 }
 
 export async function findOrCreateArticleDirectory({


### PR DESCRIPTION
If a collection or global has more than 10 files on CrowdIn, the following error will be given in the popup that appears in Payload CMS on save:

```
Invalid name given. Name must be unique
```

On investigation, this is due to an inefficient logic to retrieve the existing CrowdIn file details from Payload CMS. The default limit on `find` queries is `10`, which means that some files will be excluded if there are more than 10 CrowdIn files.

This fix resolves this by increasing the limit to an arbitrary high value. However, the actual operation should be refactored to look for the file using Payload's local API more effectively. As documented in https://github.com/thompsonsj/payload-crowdin-sync#testing, better testing should be introduced to make this type of bug easier to avoid/diagnose.

An improvement is made to the feedback for this error. Instead of suggesting to the user that there is a problem with the save operation, a `try`/`catch` block is introduced to report the error to the console for `Invalid name given. Name must be unique` along with the parameters that were sent to the function.

Example:

```
CrowdinValidationError: Invalid name given. Name must be unique
    at handleHttpClientError (/<plugin-directory>/node_modules/@crowdin/crowdin-api-client/out/core/index.js:67:15)
    at /<plugin-directory>/node_modules/@crowdin/crowdin-api-client/out/core/index.js:232:29
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  code: 400,
  validationCodes: [ { key: 'name', codes: [Array] } ]
} {
  name: 'fields.json',
  title: 'fields',
  storageId: 1881942825,
  directoryId: 1759,
  type: 'json'
}
```