### PR TITLE
feat(utilities): offer ability to exclude localized fields

### DIFF
--- a/src/utilities/getLocalizedFields.spec.ts
+++ b/src/utilities/getLocalizedFields.spec.ts
@@ -14,6 +14,31 @@ describe("fn: getLocalizedFields", () => {
       expect(getLocalizedFields({ fields })).toEqual(fields)
     })
 
+    it("excludes a localized text field based on the admin description", () => {
+      const fields: Field[] = [
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'textLocalizedFieldWithExcludeDescription',
+          type: 'text',
+          localized: true,
+          admin: {
+            description: "Not sent to CrowdIn. Localize in the CMS.",
+          }
+        },
+      ]
+      expect(getLocalizedFields({ fields })).toEqual([
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+      ])
+    })
+
     it("includes a richText field", () => {
       const fields: Field[] = [
         {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -129,7 +129,15 @@ export const getFieldSlugs = (fields: FieldWithName[]): string[] => fields.filte
 
 const hasLocalizedProp = (field: Field) => "localized" in field && field.localized
 
-export const isLocalizedField = (field: Field, addLocalizedProp: boolean = false) => (hasLocalizedProp(field) || addLocalizedProp) && localizedFieldTypes.includes(field.type)
+export const isLocalizedField = (field: Field, addLocalizedProp: boolean = false) => (hasLocalizedProp(field) || addLocalizedProp) && localizedFieldTypes.includes(field.type) && !excludeBasedOnDescription(field)
+
+const excludeBasedOnDescription = (field: Field) => {
+  const description = get(field, 'admin.description', '')
+  if (description.includes("Not sent to CrowdIn. Localize in the CMS.")) {
+    return true
+  }
+  return false
+}
 
 export const containsLocalizedFields = ({
   fields,


### PR DESCRIPTION
A bit rough, but works - exclude localized fields from syncing with CrowdIn if the field admin description contains a very specific string! `Not sent to CrowdIn. Localize in the CMS.`.