### PR TITLE
build(afterchange): fail silently if no token

### DIFF
--- a/src/hooks/collections/afterChange.ts
+++ b/src/hooks/collections/afterChange.ts
@@ -87,6 +87,13 @@ const performAfterChange = async ({
   global = false,
   pluginOptions,
 }: IPerformChange) => {
+  /**
+   * Abort if token not set and not in test mode
+   */
+  if (!pluginOptions.token && process.env.NODE_ENV !== 'test') {
+    return doc
+  }
+
   const localizedFields: Field[] = getLocalizedFields({fields: collection.fields})
 
   /**


### PR DESCRIPTION
Will replace with plugin option schema validation using https://github.com/hapijs/joi when I have time!

For now, this represents a useful way to disable the plugin in local environments - simply don't provide the token (which ideally is supplied through `.env`).