### PR TITLE
fix(files): fixes following #52

### DIFF
--- a/src/api/mock/crowdin-client.ts
+++ b/src/api/mock/crowdin-client.ts
@@ -113,6 +113,41 @@ class crowdinAPIWrapper {
     return file
   }
 
+  async updateOrRestoreFile(projectId: number, fileId: number, {
+    storageId,
+  }: SourceFilesModel.ReplaceFileFromStorageRequest ): Promise<ResponseObject<SourceFilesModel.File>> {
+    /*const storageId = await this.addStorage({
+      name,
+      fileData,
+      fileType,
+    })*/
+    const file = await Promise.resolve(1).then(() => {
+      const date = new Date().toISOString()
+      return {
+        data: {
+          revisionId: 5,
+          status: 'active',
+          priority: 'normal' as SourceFilesModel.Priority,
+          importOptions: {} as any,
+          exportOptions: {} as any,
+          excludedTargetLanguages: [],
+          createdAt: date,
+          updatedAt: date,
+          id: 1079,
+          projectId,
+          branchId: this.branchId,
+          directoryId: this.directoryId as number,
+          name: 'file',
+          title: 'file',
+          type: 'html',
+          path: `/policies/security-and-privacy/file.filetype`,
+          parserVersion: 3,
+        }
+      }
+    })
+    return file
+  }
+
   async buildProjectFileTranslation(projectId: number, fileId: number, {
     targetLanguageId,
   }: TranslationsModel.BuildProjectFileTranslationRequest): Promise<ResponseObject<TranslationsModel.BuildProjectFileTranslationResponse>> {

--- a/src/api/payload-crowdin-sync/files.ts
+++ b/src/api/payload-crowdin-sync/files.ts
@@ -250,7 +250,7 @@ export class payloadCrowdInSyncFilesApi {
   
     const payloadCrowdInFile = await this.payload.update({
       collection: 'crowdin-files', // required
-      id: crowdInFile.fileId,
+      id: crowdInFile.id,
       data: { // required
         updatedAt: updatedCrowdInFile.data.updatedAt,
         revisionId: updatedCrowdInFile.data.revisionId,

--- a/src/utilities/tests/buildJsonCrowdinObject/array-field-type.spec.ts
+++ b/src/utilities/tests/buildJsonCrowdinObject/array-field-type.spec.ts
@@ -3,6 +3,75 @@ import { buildCrowdinJsonObject, getLocalizedFields } from "../.."
 import { FieldWithName } from "../../../types"
 
 describe("fn: buildCrowdinJsonObject: array field type", () => {
+  it ("do not include non-localized fields nested in an array", () => {
+    const doc = {
+      id: '638641358b1a140462752076',
+      title: 'Test Policy created with title',
+      arrayField: [
+        {
+          title: "Array field title content one",
+          text: "Array field text content one",
+          select: "two",
+          id: "64735620230d57bce946d370"
+        },
+        {
+          title: "Array field title content two",
+          text: "Array field text content two",
+          select: "two",
+          id: "64735621230d57bce946d371"
+        }
+      ],
+      status: 'draft',
+      createdAt: '2022-11-29T17:28:21.644Z',
+      updatedAt: '2022-11-29T17:28:21.644Z'
+    }
+    const fields: FieldWithName[] = [
+      {
+        name: 'title',
+        type: 'text',
+        localized: true,
+      },
+      // select not supported yet
+      {
+        name: 'select',
+        type: 'select',
+        localized: true,
+        options: [
+          'one',
+          'two'
+        ]
+      },
+      {
+        name: 'arrayField',
+        type: 'array',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'text',
+            type: 'text',
+          },
+          {
+            name: 'select',
+            type: 'select',
+            localized: true,
+            options: [
+              'one',
+              'two'
+            ]
+          },
+        ]
+      },
+    ]
+    const localizedFields = getLocalizedFields({ fields })
+    const expected = {
+      title: 'Test Policy created with title',
+    }
+    expect(buildCrowdinJsonObject({doc, fields: localizedFields})).toEqual(expected)
+  })
+
   it ("includes localized fields nested in an array", () => {
     const doc = {
       id: '638641358b1a140462752076',


### PR DESCRIPTION
https://github.com/thompsonsj/payload-crowdin-sync/pull/52 applied a fix where CrowdIn files were always being created - the logic was incorrect in finding existing CrowdIn files.

This meant that a number of errors started appearing in the test suite once the logic started trying to update files!

This highlights a big weakness in the test suite - there are no tests for CrowdIn file updates - only tests for CrowdIn file creation. Having said that, once the issue was diagnosed against a local installation of Payload using `yarn link`, the fix caused tests to fail which is a desired result. It's clear that files are now being updated, and the logic as part of that process has been improved.