### PR TITLE
refactor(collections): simplify tests to use helpers

### DIFF
--- a/dev/src/tests/collections.test.ts
+++ b/dev/src/tests/collections.test.ts
@@ -1,5 +1,6 @@
 import payload from 'payload';
 import { initPayloadTest } from './helpers/config';
+import { getFilesByDocumentID, getFileByDocumentID } from '../../../dist/api/helpers';
 
 /**
  * Test the collections
@@ -113,20 +114,9 @@ describe('Collections', () => {
         collection: collections.localized,
         data: { title: 'Test post' },
       });
-      // retrieve post to get populated fields
-      const result = await payload.findByID({
-        collection: collections.localized,
-        id: post.id,
-      });
-      const crowdinArticleDirectoryId = result.crowdinArticleDirectory?.id
-      const crowdInFiles = await payload.find({
-        collection: 'crowdin-files',
-        where: {
-          crowdinArticleDirectory: { equals: crowdinArticleDirectoryId },
-        },
-      });
-      expect(crowdInFiles.docs.length).toEqual(1)
-      const file = crowdInFiles.docs.find(doc => doc.field === 'fields')
+      const crowdInFiles = await getFilesByDocumentID(post.id, payload)
+      expect(crowdInFiles.length).toEqual(1)
+      const file = crowdInFiles.find(doc => doc.field === 'fields')
       expect(file).not.toEqual(undefined)
       expect(file.type).toEqual('json')
     })
@@ -136,19 +126,8 @@ describe('Collections', () => {
         collection: collections.localized,
         data: { title: '' },
       });
-      // retrieve post to get populated fields
-      const result = await payload.findByID({
-        collection: collections.localized,
-        id: post.id,
-      });
-      const crowdinArticleDirectoryId = result.crowdinArticleDirectory?.id
-      const crowdInFiles = await payload.find({
-        collection: 'crowdin-files',
-        where: {
-          crowdinArticleDirectory: { equals: crowdinArticleDirectoryId },
-        },
-      });
-      expect(crowdInFiles.docs.length).toEqual(0)
+      const crowdInFiles = await getFilesByDocumentID(post.id, payload)
+      expect(crowdInFiles.length).toEqual(0)
     })
 
     const fieldsAndContentTestName = 'creates a `fields` file to include the title field and a `content` file for the content richText field'
@@ -166,21 +145,10 @@ describe('Collections', () => {
           }],
         },
       });
-      // retrieve post to get populated fields
-      const result = await payload.findByID({
-        collection: collections.localized,
-        id: post.id,
-      });
-      const crowdinArticleDirectoryId = result.crowdinArticleDirectory?.id
-      const crowdInFiles = await payload.find({
-        collection: 'crowdin-files',
-        where: {
-          crowdinArticleDirectory: { equals: crowdinArticleDirectoryId },
-        },
-      });
-      expect(crowdInFiles.docs.length).toEqual(2)
-      const fields = crowdInFiles.docs.find(doc => doc.field === 'fields')
-      const content = crowdInFiles.docs.find(doc => doc.field === 'content')
+      const crowdInFiles = await getFilesByDocumentID(post.id, payload)
+      expect(crowdInFiles.length).toEqual(2)
+      const fields = crowdInFiles.find(doc => doc.field === 'fields')
+      const content = crowdInFiles.find(doc => doc.field === 'content')
       expect(fields).not.toEqual(undefined)
       expect(fields.type).toEqual('json')
       expect(content).not.toEqual(undefined)
@@ -233,31 +201,13 @@ describe('Collections', () => {
         collection: collections.localized,
         data: { title: 'Test post' },
       });
-      // retrieve post to get populated fields
-      const result = await payload.findByID({
-        collection: collections.localized,
-        id: post.id,
-      });
-      const crowdinArticleDirectoryId = result.crowdinArticleDirectory?.id
-      const crowdInFiles = await payload.find({
-        collection: 'crowdin-files',
-        where: {
-          crowdinArticleDirectory: { equals: crowdinArticleDirectoryId },
-        },
-      });
-      const file = crowdInFiles.docs.find(doc => doc.field === 'fields')
+      const file = await getFileByDocumentID('fields', post.id, payload)
       const updatedPost = await payload.update({
         id: post.id,
         collection: collections.localized,
         data: { title: 'Test post updated' },
       });
-      const updatedCrowdInFiles = await payload.find({
-        collection: 'crowdin-files',
-        where: {
-          crowdinArticleDirectory: { equals: crowdinArticleDirectoryId },
-        },
-      });
-      const updatedFile = updatedCrowdInFiles.docs.find(doc => doc.field === 'fields')
+      const updatedFile = await getFileByDocumentID('fields', post.id, payload)
       expect(file.updatedAt).not.toEqual(updatedFile.updatedAt)
     })
   })

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,5 +1,12 @@
 import { Payload } from "payload";
 
+/**
+ * get CrowdIn Article Directory for a given documentId
+ * 
+ * The CrowdIn Article Directory is associated with a document,
+ * so is easy to retrieve. Use this function when you only have
+ * a document id.
+ */
 export async function getArticleDirectory(documentId: string, payload: Payload) {
   // Get directory
   const crowdInPayloadArticleDirectory = await payload.find({
@@ -18,7 +25,7 @@ export async function getArticleDirectory(documentId: string, payload: Payload) 
   return crowdInPayloadArticleDirectory.docs[0]
 }
 
-export async function getFile(name: string, crowdinArticleDirectoryId: number, payload: Payload): Promise<any> {
+export async function getFile(name: string, crowdinArticleDirectoryId: string, payload: Payload): Promise<any> {
   const result = await payload.find({
     collection: "crowdin-files",
     where: {
@@ -31,7 +38,7 @@ export async function getFile(name: string, crowdinArticleDirectoryId: number, p
   return result.docs[0]
 }
 
-export async function getFiles(crowdinArticleDirectoryId: number, payload: Payload): Promise<any> {
+export async function getFiles(crowdinArticleDirectoryId: string, payload: Payload): Promise<any> {
   const result = await payload.find({
     collection: "crowdin-files",
     where: {
@@ -43,7 +50,13 @@ export async function getFiles(crowdinArticleDirectoryId: number, payload: Paylo
   return result.docs
 }
 
+export async function getFileByDocumentID(name: string, documentId: string, payload: Payload): Promise<any> {
+  const articleDirectory = await getArticleDirectory(documentId, payload)
+  return getFile(name, articleDirectory.id, payload)
+}
+
 export async function getFilesByDocumentID(documentId: string, payload: Payload): Promise<any> {
   const articleDirectory = await getArticleDirectory(documentId, payload)
-  return getFiles(articleDirectory.id, payload)
+  const files = await getFiles(articleDirectory.id, payload)
+  return files
 }

--- a/src/api/payload-crowdin-sync/files.ts
+++ b/src/api/payload-crowdin-sync/files.ts
@@ -182,11 +182,11 @@ export class payloadCrowdInSyncFilesApi {
     return crowdInPayloadCollectionDirectory
   }
 
-  async getFile(name: string, crowdinArticleDirectoryId: number): Promise<any> {
+  async getFile(name: string, crowdinArticleDirectoryId: string): Promise<any> {
     return getFile(name, crowdinArticleDirectoryId, this.payload)
   }
 
-  async getFiles(crowdinArticleDirectoryId: number): Promise<any> {
+  async getFiles(crowdinArticleDirectoryId: string): Promise<any> {
     return getFiles(crowdinArticleDirectoryId, this.payload)
   }
 


### PR DESCRIPTION
It makes sense to use helpers in order to have a consistent approach to retrieving CrowdIn files.

Add a `getFileByDocumentID` helper and refactor tests in `collections.test.ts` to use helpers where appropriate.