### PR TITLE
fix(files): correct parameter for file update/delete

### DIFF
--- a/dev/src/tests/collections.test.ts
+++ b/dev/src/tests/collections.test.ts
@@ -194,21 +194,4 @@ describe('Collections', () => {
       expect(postOneRefreshed.crowdinArticleDirectory.crowdinCollectionDirectory).toEqual(postTwoRefreshed.crowdinArticleDirectory.crowdinCollectionDirectory)
     })
   })
-
-  describe('crowdin-files: on update', () => {
-    it('updates the `fields` file if a text field has changed', async () => {
-      const post = await payload.create({
-        collection: collections.localized,
-        data: { title: 'Test post' },
-      });
-      const file = await getFileByDocumentID('fields', post.id, payload)
-      const updatedPost = await payload.update({
-        id: post.id,
-        collection: collections.localized,
-        data: { title: 'Test post updated' },
-      });
-      const updatedFile = await getFileByDocumentID('fields', post.id, payload)
-      expect(file.updatedAt).not.toEqual(updatedFile.updatedAt)
-    })
-  })
 });

--- a/dev/src/tests/files.test.ts
+++ b/dev/src/tests/files.test.ts
@@ -1,6 +1,6 @@
 import payload from 'payload';
 import { initPayloadTest } from './helpers/config';
-import { getFilesByDocumentID } from '../../../dist/api/helpers';
+import { getFileByDocumentID, getFilesByDocumentID } from '../../../dist/api/helpers';
 
 /**
  * Test files
@@ -18,133 +18,152 @@ const collections = {
   nestedFields: 'nested-field-collection'
 }
 
-describe(`Collection: ${collections.nestedFields}`, () => {
+describe(`CrowdIn file create, update and delete`, () => {
   beforeEach(async () => {
     await initPayloadTest({ __dirname });
   });
 
-  it('does not create files for empty localized fields', async () => {
-    const article = await payload.create({
-      collection: collections.nestedFields,
-      data: {},
-    });
-
-    const crowdInFiles = await getFilesByDocumentID(article.id, payload)
-    expect(crowdInFiles.length).toEqual(0)
+  describe(`Collection: ${collections.localized}`, () => {
+    it('updates the `fields` file if a text field has changed', async () => {
+      const post = await payload.create({
+        collection: collections.localized,
+        data: { title: 'Test post' },
+      });
+      const file = await getFileByDocumentID('fields', post.id, payload)
+      const updatedPost = await payload.update({
+        id: post.id,
+        collection: collections.localized,
+        data: { title: 'Test post updated' },
+      });
+      const updatedFile = await getFileByDocumentID('fields', post.id, payload)
+      expect(file.updatedAt).not.toEqual(updatedFile.updatedAt)
+    })
   })
 
-  /**
-   * TODO: Fix this test
-   * 
-   * ValidationError: nested-field-collection validation failed: title.en: Cast to string failed for value "{ en: 'Test title' }" (type Object) at path "en"
-   *  model.Object.<anonymous>.Document.invalidate (dev/node_modules/mongoose/lib/document.js:3050:32)
-   * /
-  it('creates files containing fieldType content', async () => {
-    const article = await payload.create({
-      collection: collections.nestedFields,
-      locale: "en",
-      data: {
-        title: 'Test title',
-        content: [
-          {
-            children: [
-              {
-                text: "Test content"
-              }
-            ]
-          }
-        ],
-        metaDescription: 'Test meta description',
-      },
-    });
-    const crowdInFiles = await getFilesByDocumentID(article.id, payload)
-    expect(crowdInFiles.length).toEqual(2)
-    expect(crowdInFiles.find((file) => file.name === 'content.html')).toBeDefined()
-    expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
-  })
-  */
+  describe(`Collection: ${collections.nestedFields}`, () => {
+    it('does not create files for empty localized fields', async () => {
+      const article = await payload.create({
+        collection: collections.nestedFields,
+        data: {},
+      });
 
-  it('creates files containing `array` fieldType content', async () => {
-    const article = await payload.create({
-      collection: collections.nestedFields,
-      data: {
-        arrayField: [
-          {
-            title: 'Test title 1',
-            content: [
-              {
-                children: [
-                  {
-                    text: "Test content 1"
-                  }
-                ]
-              }
-            ],
-            metaDescription: 'Test meta description 1',
-          },
-          {
-            title: 'Test title 2',
-            content: [
-              {
-                children: [
-                  {
-                    text: "Test content 2"
-                  }
-                ]
-              }
-            ],
-            metaDescription: 'Test meta description 2',
-          },
-        ],
-      },
-    });
-    const crowdInFiles = await getFilesByDocumentID(article.id, payload)
-    expect(crowdInFiles.length).toEqual(3)
-    expect(crowdInFiles.find((file) => file.name === 'arrayField[0].content.html')).toBeDefined()
-    expect(crowdInFiles.find((file) => file.name === 'arrayField[1].content.html')).toBeDefined()
-    expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
-  })
+      const crowdInFiles = await getFilesByDocumentID(article.id, payload)
+      expect(crowdInFiles.length).toEqual(0)
+    })
 
-  it('creates files containing `blocks` fieldType content', async () => {
-    const article = await payload.create({
-      collection: collections.nestedFields,
-      data: {
-        layout: [
-          {
-            title: 'Test title 1',
-            content: [
-              {
-                children: [
-                  {
-                    text: "Test content 1"
-                  }
-                ]
-              }
-            ],
-            metaDescription: 'Test meta description 1',
-            blockType: 'basicBlock'
-          },
-          {
-            title: 'Test title 2',
-            content: [
-              {
-                children: [
-                  {
-                    text: "Test content 2"
-                  }
-                ]
-              }
-            ],
-            metaDescription: 'Test meta description 2',
-            blockType: 'basicBlock'
-          },
-        ],
-      },
-    });
-    const crowdInFiles = await getFilesByDocumentID(article.id, payload)
-    expect(crowdInFiles.length).toEqual(3)
-    expect(crowdInFiles.find((file) => file.name === 'layout[0].content.html')).toBeDefined()
-    expect(crowdInFiles.find((file) => file.name === 'layout[1].content.html')).toBeDefined()
-    expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
+    /**
+     * TODO: Fix this test
+     * 
+     * ValidationError: nested-field-collection validation failed: title.en: Cast to string failed for value "{ en: 'Test title' }" (type Object) at path "en"
+     *  model.Object.<anonymous>.Document.invalidate (dev/node_modules/mongoose/lib/document.js:3050:32)
+     * /
+    it('creates files containing fieldType content', async () => {
+      const article = await payload.create({
+        collection: collections.nestedFields,
+        locale: "en",
+        data: {
+          title: 'Test title',
+          content: [
+            {
+              children: [
+                {
+                  text: "Test content"
+                }
+              ]
+            }
+          ],
+          metaDescription: 'Test meta description',
+        },
+      });
+      const crowdInFiles = await getFilesByDocumentID(article.id, payload)
+      expect(crowdInFiles.length).toEqual(2)
+      expect(crowdInFiles.find((file) => file.name === 'content.html')).toBeDefined()
+      expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
+    })
+    */
+
+    it('creates files containing `array` fieldType content', async () => {
+      const article = await payload.create({
+        collection: collections.nestedFields,
+        data: {
+          arrayField: [
+            {
+              title: 'Test title 1',
+              content: [
+                {
+                  children: [
+                    {
+                      text: "Test content 1"
+                    }
+                  ]
+                }
+              ],
+              metaDescription: 'Test meta description 1',
+            },
+            {
+              title: 'Test title 2',
+              content: [
+                {
+                  children: [
+                    {
+                      text: "Test content 2"
+                    }
+                  ]
+                }
+              ],
+              metaDescription: 'Test meta description 2',
+            },
+          ],
+        },
+      });
+      const crowdInFiles = await getFilesByDocumentID(article.id, payload)
+      expect(crowdInFiles.length).toEqual(3)
+      expect(crowdInFiles.find((file) => file.name === 'arrayField[0].content.html')).toBeDefined()
+      expect(crowdInFiles.find((file) => file.name === 'arrayField[1].content.html')).toBeDefined()
+      expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
+    })
+
+    it('creates files containing `blocks` fieldType content', async () => {
+      const article = await payload.create({
+        collection: collections.nestedFields,
+        data: {
+          layout: [
+            {
+              title: 'Test title 1',
+              content: [
+                {
+                  children: [
+                    {
+                      text: "Test content 1"
+                    }
+                  ]
+                }
+              ],
+              metaDescription: 'Test meta description 1',
+              blockType: 'basicBlock'
+            },
+            {
+              title: 'Test title 2',
+              content: [
+                {
+                  children: [
+                    {
+                      text: "Test content 2"
+                    }
+                  ]
+                }
+              ],
+              metaDescription: 'Test meta description 2',
+              blockType: 'basicBlock'
+            },
+          ],
+        },
+      });
+      const crowdInFiles = await getFilesByDocumentID(article.id, payload)
+      expect(crowdInFiles.length).toEqual(3)
+      expect(crowdInFiles.find((file) => file.name === 'layout[0].content.html')).toBeDefined()
+      expect(crowdInFiles.find((file) => file.name === 'layout[1].content.html')).toBeDefined()
+      expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
+    })
   })
 });

--- a/src/api/payload-crowdin-sync/files.ts
+++ b/src/api/payload-crowdin-sync/files.ts
@@ -8,7 +8,7 @@ import { isEmpty } from 'lodash';
 
 interface IcrowdinFile {
   id: string
-  fileId: number
+  originalId: number
 }
 
 interface IfindOrCreateCollectionDirectory {
@@ -242,7 +242,7 @@ export class payloadCrowdInSyncFilesApi {
   }: IupdateFile) {
     // Update file on CrowdIn
     const updatedCrowdInFile = await this.crowdInUpdateFile({
-      fileId: crowdInFile.fileId,
+      fileId: crowdInFile.originalId,
       name,
       fileData,
       fileType,
@@ -320,7 +320,7 @@ export class payloadCrowdInSyncFilesApi {
   }
 
   private async deleteFile(crowdInFile: IcrowdinFile) {
-    const file = await this.sourceFilesApi.deleteFile(this.projectId, crowdInFile.fileId)
+    const file = await this.sourceFilesApi.deleteFile(this.projectId, crowdInFile.originalId)
     const payloadFile = await this.payload.delete({
       collection: 'crowdin-files', // required
       id: crowdInFile.id, // required


### PR DESCRIPTION
An non-existing parameter on `crowdin-files` articles is used in CrowdIn file update and delete operations. Rename the non-existing `fileId` to `originalId`.

This is not tested effectively, and the bug was found by console logging on a local Payload installation. See details below.

Ideally, tests will be refactored to use `nock` for CrowdIn api calls rather than a mock client. Furthermore, the `payload-types.ts` file could be used to pass stronger typing for `crowdin-files` articles.

Ideas for improvement, but merging this fix now because it works locally.

## Details

Tried to publish a `localized-landing-pages` article that does not have an entry on CrowdIn and got the following error which reports as a 404 error on the frontend.

```
[09:19:56] ERROR (payload): Error: Request failed with status code 404
--
[2023-07-03T09:19:56] | at handleHttpClientError (/workspace/node_modules/@crowdin/crowdin-api-client/out/core/index.js:75:15)
[2023-07-03T09:19:56] | at /workspace/node_modules/@crowdin/crowdin-api-client/out/core/index.js:240:29
[2023-07-03T09:19:56] | at runMicrotasks (<anonymous>)
[2023-07-03T09:19:56] | at processTicksAndRejections (node:internal/process/task_queues:96:5)

```

Because these operations run on an `afterChange` hook, updates can still go through - and it doesn't impact Payload saving to the database. Interesting that CrowdIn has received updates:

<img width="1596" alt="Screenshot 2023-07-03 at 10 22 59" src="https://github.com/thompsonsj/payload-crowdin-sync/assets/44806974/ef75ca02-9ac6-49af-91b5-9e5ac114d929">

More details from console logging around `/workspace/node_modules/@crowdin/crowdin-api-client/out/core/index.js:240:29` locally in `node_modules` (CrowdIn token removed):

```
put https://api.crowdin.com/api/v2/projects/323731/files/undefined { storageId: 1897894723 } {
  headers: {
    Authorization: 'Bearer <crowdin-api-token>'
  }
}
```

This looks like an `updateOrRestoreFile` request. See https://developer.crowdin.com/api/v2/#operation/api.projects.files.put. It suggests `fileId` is not being set correctly.