### PR TITLE
fix(utilities): exclude id properties from arrays

### DIFF
--- a/dev/src/collections/NestedFieldCollection.ts
+++ b/dev/src/collections/NestedFieldCollection.ts
@@ -6,6 +6,32 @@ const LocalizedBlock: Block = {
   fields: basicLocalizedFields,
 };
 
+const TestBlockArrayOfRichText: Block = {
+  slug: 'testBlockArrayOfRichText',
+  fields: [{
+    name: 'title',
+    type: 'text',
+    localized: true,
+  },
+  {
+    name: 'messages',
+    type: 'array',
+    localized: true,
+    maxRows: 3,
+    fields: [
+      {
+        name: 'title',
+        type: 'text',
+        localized: true,
+      },
+      {
+        name: 'message',
+        type: 'richText'
+      }
+    ]
+  },],
+}
+
 const NestedFieldCollection: CollectionConfig = {
   slug: 'nested-field-collection',
   access: {
@@ -27,14 +53,15 @@ const NestedFieldCollection: CollectionConfig = {
       type: 'blocks', // required
       blocks: [
         LocalizedBlock,
+        TestBlockArrayOfRichText,
       ],
     },
     // collapsible
-    {
+    /*{
       label: 'Collapsible',
       type: 'collapsible',
       fields: basicLocalizedFields,
-    },
+    },*/
     // group
     {
       name: "group", // required
@@ -63,7 +90,18 @@ const NestedFieldCollection: CollectionConfig = {
         {
           name: "tabTwo",
           label: "Tab Two Label",
-          fields: basicLocalizedFields,
+          fields: [
+            {
+              name: 'tabTwoTitle',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'tabTwoContent',
+              type: 'richText',
+              localized: true,
+            },
+          ],
         },
       ],
     },

--- a/dev/src/tests/files.test.ts
+++ b/dev/src/tests/files.test.ts
@@ -66,7 +66,7 @@ describe(`CrowdIn file create, update and delete`, () => {
      * 
      * ValidationError: nested-field-collection validation failed: title.en: Cast to string failed for value "{ en: 'Test title' }" (type Object) at path "en"
      *  model.Object.<anonymous>.Document.invalidate (dev/node_modules/mongoose/lib/document.js:3050:32)
-     * /
+     */
     it('creates files containing fieldType content', async () => {
       const article = await payload.create({
         collection: collections.nestedFields,
@@ -90,7 +90,6 @@ describe(`CrowdIn file create, update and delete`, () => {
       expect(crowdInFiles.find((file) => file.name === 'content.html')).toBeDefined()
       expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
     })
-    */
 
     it('creates files containing `array` fieldType content', async () => {
       const article = await payload.create({
@@ -153,27 +152,53 @@ describe(`CrowdIn file create, update and delete`, () => {
               blockType: 'basicBlock'
             },
             {
-              title: 'Test title 2',
-              content: [
+              messages: [
                 {
-                  children: [
+                  message: [
                     {
-                      text: "Test content 2"
+                      children: [
+                        {
+                          text: "Test content 1"
+                        }
+                      ]
                     }
-                  ]
+                  ],
+                  id: "64735620230d57bce946d370"
+                },
+                {
+                  message: [
+                    {
+                      children: [
+                        {
+                          text: "Test content 1"
+                        }
+                      ]
+                    }
+                  ],
+                  id: "64735621230d57bce946d371"
                 }
               ],
-              metaDescription: 'Test meta description 2',
-              blockType: 'basicBlock'
+              blockType: 'testBlockArrayOfRichText',
             },
           ],
         },
       });
       const crowdInFiles = await getFilesByDocumentID(article.id, payload)
-      expect(crowdInFiles.length).toEqual(3)
+      expect(crowdInFiles.length).toEqual(4)
+      const jsonFile = crowdInFiles.find((file) => file.name === 'fields.json')
       expect(crowdInFiles.find((file) => file.name === 'layout[0].content.html')).toBeDefined()
-      expect(crowdInFiles.find((file) => file.name === 'layout[1].content.html')).toBeDefined()
-      expect(crowdInFiles.find((file) => file.name === 'fields.json')).toBeDefined()
+      expect(crowdInFiles.find((file) => file.name === 'layout[1].messages[0].message.html')).toBeDefined()
+      expect(crowdInFiles.find((file) => file.name === 'layout[1].messages[1].message.html')).toBeDefined()
+      expect(jsonFile).toBeDefined()
+      expect(jsonFile.fileData.json).toEqual(
+        { 
+          layout: [
+            {
+              title: 'Test title 1',
+            }
+          ]
+        }
+      )
     })
   })
 });

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -143,7 +143,12 @@ export const getFieldSlugs = (fields: FieldWithName[]): string[] => fields.filte
 
 const hasLocalizedProp = (field: Field) => "localized" in field && field.localized
 
-export const isLocalizedField = (field: Field, addLocalizedProp: boolean = false) => (hasLocalizedProp(field) || addLocalizedProp) && localizedFieldTypes.includes(field.type) && !excludeBasedOnDescription(field)
+/**
+ * Is Localized Field
+ * 
+ * Note that `id` should be excluded - it is a `text` field that is added by Payload CMS.
+ */
+export const isLocalizedField = (field: Field, addLocalizedProp: boolean = false) => (hasLocalizedProp(field) || addLocalizedProp) && localizedFieldTypes.includes(field.type) && !excludeBasedOnDescription(field) && (field as any).name !== 'id'
 
 const excludeBasedOnDescription = (field: Field) => {
   const description = get(field, 'admin.description', '')
@@ -205,7 +210,7 @@ export const buildCrowdinJsonObject = ({
         doc: item,
         fields: field.fields,
         topLevel: false,
-      }))
+      })).filter((item: any) => !isEmpty(item))
     } else if (field.type === 'blocks') {
       response[field.name] = doc[field.name].map((item: any) => buildCrowdinJsonObject({
         doc: item,

--- a/src/utilities/tests/buildJsonCrowdinObject/combined-field-types.spec.ts
+++ b/src/utilities/tests/buildJsonCrowdinObject/combined-field-types.spec.ts
@@ -167,10 +167,6 @@ describe("fn: buildCrowdinJsonObject: group nested in array", () => {
     },
       fields: getLocalizedFields({ fields: Promos.fields })
     })).toEqual({
-      ctas: [
-        {},
-        {}
-      ],
       "text": "Get in touch with us or try it out yourself",
       "title": "Experience the magic of our product!"
     })


### PR DESCRIPTION
- Prevent fields with a `name` of `id` from identifying as a localized field.
- Exclude arrays of empty objects from `fields.json`.

## Details

`getLocalizedFields` supports top-level `localized: true` settings on fields that contain a group of fields. This support was added in https://github.com/thompsonsj/payload-crowdin-sync/pull/20.

Payload CMS adds `text` fields for the `id` in some cases: e.g. each item in an array will have it's own id. Here's an example doc with values in an array field:

```json
{
  "id": "649da59a7a48bc576d04966f",
  "arrayField": [
    {
      "content": [
        {
          "children": [
            {
              "text": "Test content 1"
            }
          ]
        }
      ],
      "metaDescription": "Test meta description 1"
    },
    {
      "content": [
        {
          "children": [
            {
              "text": "Test content 2"
            }
          ]
        }
      ],
      "metaDescription": "Test meta description 2"
    }
  ],
  "createdAt": "2023-06-29T15:39:06.628Z",
  "updatedAt": "2023-07-03T10:32:43.988Z"
}
```

In this scenario, `fields.json` can end up containing `id` fields. In the above example, each array item only contains a `richText` field - which get sent to html files instead of fields.json.

```json
{
  "arrayField": [
    {
      "id": "649cd20ebac7445191be36b0"
    },
    {
      "id": "649cd219bac7445191be36b1"
    }
  ]
}
```

Note that integration tests are written to test against this scenario. Providing fixtures to the unit tests in the `utilities` folder won't work because this situation only arises when a Payload CMS installation adds fields.