### PR TITLE
build(release-please.yml): remove testing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,9 +35,7 @@ jobs:
           cache: 'yarn'
         if: ${{ steps.release.outputs.release_created }}
       - run: yarn install --frozen-lockfile
-      - run: yarn --cwd ./dev/ install
       - run: yarn build
-      - run: yarn test
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:


### PR DESCRIPTION
The `dev` subdirectory needs to be installed for testing. However, I'm getting an error:

![Screenshot 2023-07-04 at 15 48 53](https://github.com/thompsonsj/payload-crowdin-sync/assets/44806974/6b0c7ae9-7471-4e9f-9508-55dd826a602a)

This isn't an issue in https://github.com/thompsonsj/payload-crowdin-sync/blob/main/.github/workflows/node.js.yml.

Regardless, pull requests are tested so we can remove this and only focus on the release/publish process in this action.