### PR TITLE
fix(getlocalizedfields): relax tab field detection

### DIFF
--- a/src/api/payload-crowdin-sync/files.ts
+++ b/src/api/payload-crowdin-sync/files.ts
@@ -339,7 +339,7 @@ export class payloadCrowdInSyncFilesApi {
           name: crowdInFile.data.name,
           type: crowdInFile.data.type,
           path: crowdInFile.data.path,
-          ...(fileType === "json" && { fileData: { json: value } }),
+          //...(fileType === "json" && { fileData: { json: value } }),
           ...(fileType === "html" && { fileData: { html: value } }),
         },
       });

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -31,7 +31,7 @@ export const getLocalizedFields = ({
   // flatten the presetational only tabs field
   // TODO: check this is correct. Docs at https://payloadcms.com/docs/fields/tabs suggest that subsequent tabs can be accessed using a prefix, but documents saved with tabs seem to retain their structure as if they didn't have tabs.
   let flattenedFields = fields;
-  if (fields.length === 1 && fields[0].type === "tabs") {
+  if (fields.length > 1 && fields[0].type === "tabs") {
     flattenedFields = fields[0].tabs.map((tab) => tab.fields).flat();
   }
   const localizedFields = getLocalizedFieldsRecursive({
@@ -39,8 +39,9 @@ export const getLocalizedFields = ({
     type,
     localizedParent,
   });
+  const allLocalizedFields = type ? getLocalizedFields({ fields: fields }) : fields;
   if (
-    localizedFields.length === 1 &&
+    allLocalizedFields.length === 1 &&
     get(localizedFields[0], "name") === "meta"
   ) {
     return [];

--- a/src/utilities/tests/buildJsonCrowdinObject/group-field-type.spec.ts
+++ b/src/utilities/tests/buildJsonCrowdinObject/group-field-type.spec.ts
@@ -201,4 +201,114 @@ describe("fn: buildCrowdinJsonObject: group field type", () => {
       expected,
     );
   });
+
+  it("includes localized fields nested in groups nested in a group nested in a collapsible field", () => {
+    const doc = {
+      id: "638641358b1a140462752076",
+      title: "Test Policy created with title",
+      groupField: {
+        nestedGroupField: fieldDocValue,
+        secondNestedGroupField: fieldDocValue,
+      },
+      status: "draft",
+      createdAt: "2022-11-29T17:28:21.644Z",
+      updatedAt: "2022-11-29T17:28:21.644Z",
+    };
+    const fields: Field[] = [
+      {
+        name: "title",
+        type: "text",
+        localized: true,
+      },
+      {
+        label: "collapsibleField",
+        type: "collapsible",
+        fields: [
+          {
+          name: "groupField",
+          type: "group",
+          fields: [
+            {
+              name: "nestedGroupField",
+              type: "group",
+              fields: basicLocalizedFields,
+            },
+            {
+              name: "secondNestedGroupField",
+              type: "group",
+              fields: basicLocalizedFields,
+            },
+          ],
+        },
+      ],
+    },
+    ];
+    const localizedFields = getLocalizedFields({ fields });
+    const expected = {
+      title: "Test Policy created with title",
+      groupField: {
+        nestedGroupField: fieldJsonCrowdinObject(),
+        secondNestedGroupField: fieldJsonCrowdinObject(),
+      },
+    };
+    expect(buildCrowdinJsonObject({ doc, fields: localizedFields })).toEqual(
+      expected,
+    );
+  });
+
+  it("includes localized fields nested in groups nested in a group nested in a collapsible field with top-level localization settings", () => {
+    const doc = {
+      id: "638641358b1a140462752076",
+      title: "Test Policy created with title",
+      groupField: {
+        nestedGroupField: fieldDocValue,
+        secondNestedGroupField: fieldDocValue,
+      },
+      status: "draft",
+      createdAt: "2022-11-29T17:28:21.644Z",
+      updatedAt: "2022-11-29T17:28:21.644Z",
+    };
+    const fields: Field[] = [
+      {
+        name: "title",
+        type: "text",
+        localized: true,
+      },
+      {
+        label: "collapsibleField",
+        type: "collapsible",
+        fields: [
+          {
+          name: "groupField",
+          type: "group",
+          fields: [
+            {
+              name: "nestedGroupField",
+              type: "group",
+              localized: true,
+              fields: basicNonLocalizedFields,
+            },
+            {
+              name: "secondNestedGroupField",
+              type: "group",
+              localized: true,
+              fields: basicNonLocalizedFields,
+            },
+          ],
+        },
+      ],
+    },
+    ];
+    const localizedFields = getLocalizedFields({ fields });
+    const expected = {
+      title: "Test Policy created with title",
+      groupField: {
+        nestedGroupField: fieldJsonCrowdinObject(),
+        secondNestedGroupField: fieldJsonCrowdinObject(),
+      },
+    };
+    expect(buildCrowdinJsonObject({ doc, fields: localizedFields })).toEqual(
+      expected,
+    );
+  });
 });


### PR DESCRIPTION
Check for a `tabs` field in the first field for a collection and global, and return all the fields from these tabs without the tab field definition.

This is a temporary fix - code should be refactored to flatten tabs fields in any position.

The flatten behaviour remains the best approach - tabs are presentational only.

Other unrelated changes included - may as well commit! The issue I was trying to diagnose when I wrote the additional test was caused by `localized: true` not being set on fields double-nested within fields that use the top-level `localized` feature. i.e. it was a Payload config issue.