### PR TITLE
fix(restoreorder): handle array items with empty values in source doc

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "isomorphic-fetch": "^3.0.0",
     "jest": "^29.6.1",
     "nock": "^13.3.1",
-    "prettier": "3.0.0",
+    "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"

--- a/src/api/payload-crowdin-sync/translations.ts
+++ b/src/api/payload-crowdin-sync/translations.ts
@@ -22,8 +22,6 @@ import {
   buildPayloadUpdateObject,
   getLocalizedRequiredFields,
 } from "../../utilities";
-import fs from 'fs';
-import path from 'path';
 
 interface IgetLatestDocumentTranslation {
   collection: string;
@@ -226,14 +224,6 @@ export class payloadCrowdinSyncTranslationsApi {
       doc: document,
       fields: localizedFields,
     });
-    try {
-    fs.writeFile(path.join(__dirname,'buildpayloadupdate.txt'), JSON.stringify(crowdinJsonObject), (err: any) => { if (err) {console.log(err); throw err}; });
-    } catch (error) {
-      console.log(error)
-    }
-    //fs.writeFile('buildpayloadupdate.txt', JSON.stringify(crowdinHtmlObject), (err: any) => { if (err) throw err; });
-    //fs.writeFile('buildpayloadupdate.txt', JSON.stringify(localizedFields), (err: any) => { if (err) throw err; });
-    //fs.writeFile('buildpayloadupdate.txt', JSON.stringify(document), (err: any) => { if (err) throw err; });
     try {
       const docTranslations = buildPayloadUpdateObject({
         crowdinJsonObject,

--- a/src/api/payload-crowdin-sync/translations.ts
+++ b/src/api/payload-crowdin-sync/translations.ts
@@ -22,8 +22,8 @@ import {
   buildPayloadUpdateObject,
   getLocalizedRequiredFields,
 } from "../../utilities";
-import dot from "dot-object";
-import { clone, map } from "lodash";
+import fs from 'fs';
+import path from 'path';
 
 interface IgetLatestDocumentTranslation {
   collection: string;
@@ -134,23 +134,31 @@ export class payloadCrowdinSyncTranslationsApi {
       );
       if (report[locale].changed && !dryRun) {
         if (global) {
-          await this.payload.updateGlobal({
-            slug: collection,
-            locale: locale,
-            data: {
-              ...report[locale].latestTranslations,
-              // error on update without the following line.
-              // see https://github.com/thompsonsj/payload-crowdin-sync/pull/13/files#r1209271660
-              crowdinArticleDirectory: doc.crowdinArticleDirectory.id,
-            },
-          });
+          try {
+            await this.payload.updateGlobal({
+              slug: collection,
+              locale: locale,
+              data: {
+                ...report[locale].latestTranslations,
+                // error on update without the following line.
+                // see https://github.com/thompsonsj/payload-crowdin-sync/pull/13/files#r1209271660
+                crowdinArticleDirectory: doc.crowdinArticleDirectory.id,
+              },
+            });
+          } catch (error) {
+            console.log(error)
+          }
         } else {
-          await this.payload.update({
-            collection: collection,
-            locale: locale,
-            id: documentId,
-            data: report[locale].latestTranslations,
-          });
+          try {
+            await this.payload.update({
+              collection: collection,
+              locale: locale,
+              id: documentId,
+              data: report[locale].latestTranslations,
+            });
+          } catch (error) {
+            console.log(error)
+          }
         }
       }
     }
@@ -218,14 +226,26 @@ export class payloadCrowdinSyncTranslationsApi {
       doc: document,
       fields: localizedFields,
     });
-    const docTranslations = buildPayloadUpdateObject({
-      crowdinJsonObject,
-      crowdinHtmlObject,
-      fields: localizedFields,
-      document,
-    });
-
-    return docTranslations;
+    try {
+    fs.writeFile(path.join(__dirname,'buildpayloadupdate.txt'), JSON.stringify(crowdinJsonObject), (err: any) => { if (err) {console.log(err); throw err}; });
+    } catch (error) {
+      console.log(error)
+    }
+    //fs.writeFile('buildpayloadupdate.txt', JSON.stringify(crowdinHtmlObject), (err: any) => { if (err) throw err; });
+    //fs.writeFile('buildpayloadupdate.txt', JSON.stringify(localizedFields), (err: any) => { if (err) throw err; });
+    //fs.writeFile('buildpayloadupdate.txt', JSON.stringify(document), (err: any) => { if (err) throw err; });
+    try {
+      const docTranslations = buildPayloadUpdateObject({
+        crowdinJsonObject,
+        crowdinHtmlObject,
+        fields: localizedFields,
+        document,
+      });
+      return docTranslations;
+    } catch (error) {
+      console.log(error)
+      throw new Error(`${error}`);
+    }
   }
 
   /**
@@ -317,17 +337,21 @@ export class payloadCrowdinSyncTranslationsApi {
     if (!file) {
       return;
     }
-    const response = await this.translationsApi.buildProjectFileTranslation(
-      this.projectId,
-      file.originalId,
-      {
-        targetLanguageId: this.localeMap[locale].crowdinId,
-      },
-    );
-    const data = await this.getFileDataFromUrl(response.data.url);
-    return file.type === "html"
-      ? htmlToSlate(data, payloadHtmlToSlateConfig)
-      : JSON.parse(data);
+    try {
+      const response = await this.translationsApi.buildProjectFileTranslation(
+        this.projectId,
+        file.originalId,
+        {
+          targetLanguageId: this.localeMap[locale].crowdinId,
+        },
+      );
+      const data = await this.getFileDataFromUrl(response.data.url);
+      return file.type === "html"
+        ? htmlToSlate(data, payloadHtmlToSlateConfig)
+        : JSON.parse(data);
+    } catch (error) {
+      console.log(error)
+    }
   }
 
   private async getFileDataFromUrl(url: string) {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -248,7 +248,7 @@ export const restoreOrder = ({
     return updateDocument;
   }
   fields.forEach((field: any) => {
-    if (!updateDocument[field.name]) {
+    if (!updateDocument || !updateDocument[field.name]) {
       return;
     }
     if (field.type === "group") {
@@ -262,6 +262,9 @@ export const restoreOrder = ({
         const arrayItem = updateDocument[field.name].find((updateItem: any) => {
           return updateItem.id === item.id;
         });
+        if (!arrayItem) {
+          return;
+        }
         const subFields =
           field.type === "blocks"
             ? field.blocks.find((block: Block) => block.slug === item.blockType)
@@ -276,7 +279,7 @@ export const restoreOrder = ({
           id: arrayItem.id,
           ...(field.type === "blocks" && { blockType: arrayItem.blockType }),
         };
-      });
+      }).filter((item: any) => !isEmpty(item));
     } else {
       response[field.name] = updateDocument[field.name];
     }

--- a/src/utilities/tests/inline-snapshots/book-demo.test.ts
+++ b/src/utilities/tests/inline-snapshots/book-demo.test.ts
@@ -1,0 +1,83 @@
+import BookDemo from "./collections/BookDemo";
+import { getLocalizedFields } from "../..";
+
+describe("book demo collection snapshots", () => {
+  const fields = BookDemo.fields;
+
+  it("getLocalizedFields", () => {
+    expect(getLocalizedFields({ fields })).toMatchInlineSnapshot(`
+      [
+        {
+          "localized": true,
+          "name": "logoTitle",
+          "required": true,
+          "type": "text",
+        },
+        {
+          "fields": [
+            {
+              "admin": {
+                "elements": [],
+                "leaves": [
+                  "bold",
+                ],
+              },
+              "name": "title",
+              "type": "richText",
+            },
+            {
+              "admin": {
+                "elements": [],
+                "leaves": [
+                  "bold",
+                ],
+              },
+              "name": "text",
+              "type": "richText",
+            },
+          ],
+          "localized": true,
+          "name": "hero",
+          "type": "group",
+        },
+        {
+          "fields": [
+            {
+              "name": "title",
+              "type": "text",
+            },
+            {
+              "name": "subTitle",
+              "type": "text",
+            },
+            {
+              "fields": [
+                {
+                  "name": "title",
+                  "type": "text",
+                },
+                {
+                  "fields": [
+                    {
+                      "name": "text",
+                      "type": "text",
+                    },
+                  ],
+                  "localized": true,
+                  "name": "items",
+                  "type": "array",
+                },
+              ],
+              "localized": true,
+              "name": "content",
+              "type": "group",
+            },
+          ],
+          "localized": true,
+          "name": "form",
+          "type": "group",
+        },
+      ]
+    `);
+  });
+});

--- a/src/utilities/tests/inline-snapshots/book-demo.test.ts
+++ b/src/utilities/tests/inline-snapshots/book-demo.test.ts
@@ -1,8 +1,104 @@
 import BookDemo from "./collections/BookDemo";
-import { getLocalizedFields } from "../..";
+import {
+  buildCrowdinJsonObject,
+  buildCrowdinHtmlObject,
+  buildPayloadUpdateObject,
+  getLocalizedFields,
+} from "../..";
 
 describe("book demo collection snapshots", () => {
+  const doc = {
+    hero: {
+      title: [
+        {
+          type: "p",
+          children: [
+            {
+              text: "Réservez une démo",
+            },
+          ],
+        },
+      ],
+      text: [
+        {
+          type: "p",
+          children: [
+            {
+              text: "Apprenez comment Acme Corp peut vous aider à ",
+            },
+            {
+              text: "atteindre vos objectifs",
+              bold: true,
+            },
+            {
+              text: ". Nous sommes prêts à parier que vous apprendrez quelque chose de nouveau lors de notre rencontre. Et si ce n’est pas le cas, on vous offre un cupcake ! 😉",
+            },
+          ],
+        },
+      ],
+    },
+    form: {
+      title: "Réservez une démo",
+      subTitle:
+        "Nous vous contacterons dès que possible pour fixer une heure qui vous convienne.",
+      content: {
+        title: "",
+        items: [
+          {
+            text: "",
+            id: "64a8af5656f68b0022bfd267",
+          },
+          {
+            text: "Offres d'emploi et utilisateurs illimités",
+            id: "64a8af5656f68b0022bfd268",
+          },
+          {
+            text: "",
+            id: "64a8af5656f68b0022bfd269",
+          },
+          {
+            text: "",
+            id: "64a8af5656f68b0022bfd26a",
+          },
+          {
+            text: "",
+            id: "64a8af5656f68b0022bfd26b",
+          },
+          {
+            text: "Des présentations produits et des webinaires gratuits",
+            id: "64a8af5656f68b0022bfd26c",
+          },
+          {
+            text: "Un accès complet à l'Académie Acme Corp",
+            id: "64a8af5656f68b0022bfd26d",
+          },
+        ],
+      },
+    },
+    logoTitle: "Adoré par les meilleurs recruteurs internationaux",
+    promo: "6474f51370b180880beb4bcb",
+    meta: {
+      title: "Réservez une démo | Acme Corp",
+      description:
+        "Book a demo of Acme Corp Widget and let our team show you the magic of our product! Schedule a call with one of team members here.",
+    },
+    crowdinArticleDirectory: "6486e2a7715834a0e4b7cea4",
+    _status: "published",
+    globalType: "book-demo",
+    createdAt: "2023-06-12T07:43:55.361Z",
+    updatedAt: "2023-07-25T09:43:57.619Z",
+    id: "6486ccbb27a4f59700b066ec",
+  };
   const fields = BookDemo.fields;
+  const localizedFields = getLocalizedFields({ fields });
+  const crowdinJsonObject = buildCrowdinJsonObject({
+    doc,
+    fields: localizedFields,
+  });
+  const crowdinHtmlObject = buildCrowdinHtmlObject({
+    doc,
+    fields: localizedFields,
+  });
 
   it("getLocalizedFields", () => {
     expect(getLocalizedFields({ fields })).toMatchInlineSnapshot(`
@@ -79,5 +175,74 @@ describe("book demo collection snapshots", () => {
         },
       ]
     `);
+  });
+
+  it("buildCrowdinJsonObject", () => {
+    expect(crowdinJsonObject).toMatchInlineSnapshot(`
+      {
+        "form": {
+          "content": {
+            "items": {
+              "64a8af5656f68b0022bfd268": {
+                "text": "Offres d'emploi et utilisateurs illimités",
+              },
+              "64a8af5656f68b0022bfd26c": {
+                "text": "Des présentations produits et des webinaires gratuits",
+              },
+              "64a8af5656f68b0022bfd26d": {
+                "text": "Un accès complet à l'Académie Acme Corp",
+              },
+            },
+          },
+          "subTitle": "Nous vous contacterons dès que possible pour fixer une heure qui vous convienne.",
+          "title": "Réservez une démo",
+        },
+        "logoTitle": "Adoré par les meilleurs recruteurs internationaux",
+      }
+    `);
+  });
+
+  it("buildCrowdinHtmlObject", () => {
+    expect(crowdinHtmlObject).toMatchInlineSnapshot(`
+      {
+        "hero.text": [
+          {
+            "children": [
+              {
+                "text": "Apprenez comment Acme Corp peut vous aider à ",
+              },
+              {
+                "bold": true,
+                "text": "atteindre vos objectifs",
+              },
+              {
+                "text": ". Nous sommes prêts à parier que vous apprendrez quelque chose de nouveau lors de notre rencontre. Et si ce n’est pas le cas, on vous offre un cupcake ! 😉",
+              },
+            ],
+            "type": "p",
+          },
+        ],
+        "hero.title": [
+          {
+            "children": [
+              {
+                "text": "Réservez une démo",
+              },
+            ],
+            "type": "p",
+          },
+        ],
+      }
+    `);
+  });
+
+  it("buildPayloadUpdateObject", () => {
+    const docTranslations = buildPayloadUpdateObject({
+      crowdinJsonObject,
+      crowdinHtmlObject,
+      fields: localizedFields,
+      document: doc,
+    });
+    expect(docTranslations).toMatchInlineSnapshot();
   });
 });

--- a/src/utilities/tests/inline-snapshots/book-demo.test.ts
+++ b/src/utilities/tests/inline-snapshots/book-demo.test.ts
@@ -243,6 +243,59 @@ describe("book demo collection snapshots", () => {
       fields: localizedFields,
       document: doc,
     });
-    expect(docTranslations).toMatchInlineSnapshot();
+    expect(docTranslations).toMatchInlineSnapshot(`
+      {
+        "form": {
+          "content": {
+            "items": [
+              {
+                "id": "64a8af5656f68b0022bfd268",
+                "text": "Offres d'emploi et utilisateurs illimités",
+              },
+              {
+                "id": "64a8af5656f68b0022bfd26c",
+                "text": "Des présentations produits et des webinaires gratuits",
+              },
+              {
+                "id": "64a8af5656f68b0022bfd26d",
+                "text": "Un accès complet à l'Académie Acme Corp",
+              },
+            ],
+          },
+          "subTitle": "Nous vous contacterons dès que possible pour fixer une heure qui vous convienne.",
+          "title": "Réservez une démo",
+        },
+        "hero": {
+          "text": [
+            {
+              "children": [
+                {
+                  "text": "Apprenez comment Acme Corp peut vous aider à ",
+                },
+                {
+                  "bold": true,
+                  "text": "atteindre vos objectifs",
+                },
+                {
+                  "text": ". Nous sommes prêts à parier que vous apprendrez quelque chose de nouveau lors de notre rencontre. Et si ce n’est pas le cas, on vous offre un cupcake ! 😉",
+                },
+              ],
+              "type": "p",
+            },
+          ],
+          "title": [
+            {
+              "children": [
+                {
+                  "text": "Réservez une démo",
+                },
+              ],
+              "type": "p",
+            },
+          ],
+        },
+        "logoTitle": "Adoré par les meilleurs recruteurs internationaux",
+      }
+    `);
   });
 });

--- a/src/utilities/tests/inline-snapshots/collections/BookDemo.ts
+++ b/src/utilities/tests/inline-snapshots/collections/BookDemo.ts
@@ -1,0 +1,69 @@
+import { GlobalConfig } from 'payload/types';
+import { heroField } from './shared/heroField';
+import { collapsibleFields as cf } from './shared/collapsibleFields';
+
+const BookDemo: GlobalConfig = {
+  slug: 'book-demo',
+  access: {
+    read: () => true,
+  },
+  versions: {
+    drafts: true,
+  },
+  admin: {
+    group: 'Static Pages',
+  },
+  fields: [
+    cf('Hero', [heroField({ image: true })]),
+    cf('Form', [
+      {
+        type: 'group',
+        name: 'form',
+        localized: true,
+        fields: [
+          {
+            type: 'text',
+            name: 'title',
+          },
+          {
+            type: 'text',
+            name: 'subTitle',
+          },
+          {
+            type: 'group',
+            name: 'content',
+            localized: true,
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+              },
+              {
+                name: 'items',
+                type: 'array',
+                localized: true,
+                fields: [{ type: 'text', name: 'text' }],
+              },
+            ],
+          },
+        ],
+      },
+    ]),
+    {
+      name: 'logoTitle',
+      type: 'text',
+      required: true,
+      localized: true,
+    },
+    cf('Promo', [
+      {
+        name: 'promo',
+        type: 'relationship',
+        relationTo: 'promos',
+        hasMany: false,
+      },
+    ]),
+  ],
+};
+
+export default BookDemo;

--- a/src/utilities/tests/inline-snapshots/collections/shared/collapsibleFields.ts
+++ b/src/utilities/tests/inline-snapshots/collections/shared/collapsibleFields.ts
@@ -1,0 +1,10 @@
+import { Field } from 'payload/types';
+
+export const collapsibleFields = (label: string, fields: any): Field => ({
+  type: 'collapsible',
+  label,
+  admin: {
+    initCollapsed: true,
+  },
+  fields,
+});

--- a/src/utilities/tests/inline-snapshots/collections/shared/heroField.ts
+++ b/src/utilities/tests/inline-snapshots/collections/shared/heroField.ts
@@ -1,0 +1,63 @@
+interface IHeroFieldOptions {
+  image?: boolean;
+  badge?: boolean;
+}
+
+const defaultOptions = { image: false, badge: false };
+
+export const heroField = (options: IHeroFieldOptions = {}): any => {
+  options = { ...defaultOptions, ...options };
+
+  const config = {
+    name: 'hero',
+    type: 'group',
+    localized: true,
+    fields: [
+      {
+        name: 'title',
+        type: 'richText',
+        admin: {
+          elements: [],
+          leaves: ['bold'],
+        },
+      },
+      {
+        name: 'text',
+        type: 'richText',
+        admin: {
+          elements: [],
+          leaves: ['bold'],
+        },
+      },
+      options.badge && {
+        name: 'badge',
+        type: 'group',
+        localized: true,
+        fields: [
+          {
+            name: 'badgeText',
+            type: 'text',
+          },
+          {
+            name: 'text',
+            type: 'text',
+          },
+          {
+            name: 'link',
+            type: 'text',
+            admin: {
+              description: "Not sent to CrowdIn. Localize in the CMS.",
+            }
+          },
+        ],
+      },
+      options.image && {
+        name: 'image',
+        type: 'upload',
+        relationTo: 'media',
+      },
+    ].filter(Boolean),
+  };
+
+  return config;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7894,12 +7894,7 @@ prebuild-install@^7.1.1:
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
 
-prettier@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
-  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
-
-prettier@^2.6.2:
+prettier@^2.6.2, prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==


### PR DESCRIPTION
Fix `buildPayloadUpdateObject` when the original document contains empty values in localized array items. `buildPayloadUpdateObject` uses `restoreOrder`, and this is where the appropriate checks are added.

## Downgrade `prettier`

A `prettier` downgrade is required to use inline snapshots in Jest.

```
Test suite failed to run

    TypeError: prettier.resolveConfig.sync is not a function

      at runPrettier (node_modules/jest-snapshot/build/InlineSnapshots.js:308:30)
```