### PR TITLE
fix(getlocalizedfields): support top-level tabs fields

### DIFF
--- a/src/utilities/tests/getLocalizedFields/tabs-field-type.spec.ts
+++ b/src/utilities/tests/getLocalizedFields/tabs-field-type.spec.ts
@@ -1,0 +1,216 @@
+import { Field } from "payload/types";
+import { getLocalizedFields } from "./../../";
+import { basicLocalizedFields } from "../fixtures/basic-localized-fields.fixture";
+
+describe('presentation only tab fields', () => {
+  it('returns an empty array if no localized fields in tabs', () => {
+    // fixture from https://payloadcms.com/docs/fields/tabs
+    const fields: Field[] = [
+      {
+        type: "tabs", // required
+        tabs: [
+          // required
+          {
+            label: "Tab One Label", // required
+            description: "This will appear within the tab above the fields.",
+            fields: [
+              // required
+              {
+                name: "someTextField",
+                type: "text",
+                required: true,
+              },
+            ],
+          },
+          {
+            name: "tabTwo",
+            label: "Tab Two Label", // required
+            interfaceName: "TabTwo", // optional (`name` must be present)
+            fields: [
+              // required
+              {
+                name: "numberField", // accessible via tabTwo.numberField
+                type: "number",
+                required: true,
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    expect(getLocalizedFields({ fields })).toEqual([])
+  })
+
+  it('returns localized fields in tabs', () => {
+    // fixture from https://payloadcms.com/docs/fields/tabs
+    const fields: Field[] = [
+      {
+        type: "tabs", // required
+        tabs: [
+          // required
+          {
+            label: "Tab One Label", // required
+            description: "This will appear within the tab above the fields.",
+            fields: [
+              // required
+              {
+                name: "someTextField",
+                type: "text",
+                required: true,
+                localized: true,
+              },
+            ],
+          },
+          {
+            name: "tabTwo",
+            label: "Tab Two Label", // required
+            interfaceName: "TabTwo", // optional (`name` must be present)
+            fields: [
+              // required
+              {
+                name: "numberField", // accessible via tabTwo.numberField
+                type: "number",
+                required: true,
+                localized: true,
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    expect(getLocalizedFields({ fields })).toEqual([
+      {
+        "localized": true,
+        "name": "someTextField",
+        "required": true,
+        "type": "text",
+       }
+    ])
+  })
+
+  it('returns localized fields in tab respecting tab names', () => {
+    // fixture from https://payloadcms.com/docs/fields/tabs
+    const fields: Field[] = [
+      {
+        type: "tabs", // required
+        tabs: [
+          // required
+          {
+            label: "Tab One Label", // required
+            description: "This will appear within the tab above the fields.",
+            fields: basicLocalizedFields,
+          },
+          {
+            name: "tabTwo",
+            label: "Tab Two Label", // required
+            interfaceName: "TabTwo", // optional (`name` must be present)
+            fields: basicLocalizedFields,
+          },
+        ],
+      },
+    ]
+
+    expect(getLocalizedFields({ fields })).toEqual([
+      {
+        fields: [
+          {
+            name: "textField",
+            type: "text",
+            localized: true,
+          },
+          {
+            name: "textareaField",
+            type: "textarea",
+            localized: true,
+          },
+        ],
+        name: "tabTwo",
+        type: "group",
+      },
+      {
+        name: "textField",
+        type: "text",
+        localized: true,
+      },
+      {
+        name: "textareaField",
+        type: "textarea",
+        localized: true,
+      },
+    ])
+  })
+
+  it('returns localized fields in tab respecting tab names with other fields', () => {
+    // fixture from https://payloadcms.com/docs/fields/tabs
+    const fields: Field[] = [
+      {
+        name: "textFieldExtra",
+        type: "text",
+        localized: true,
+      },
+      {
+        name: "textareaFieldExtra",
+        type: "textarea",
+        localized: true,
+      },
+      {
+        type: "tabs", // required
+        tabs: [
+          // required
+          {
+            label: "Tab One Label", // required
+            description: "This will appear within the tab above the fields.",
+            fields: basicLocalizedFields,
+          },
+          {
+            name: "tabTwo",
+            label: "Tab Two Label", // required
+            interfaceName: "TabTwo", // optional (`name` must be present)
+            fields: basicLocalizedFields,
+          },
+        ],
+      },
+    ]
+
+    expect(getLocalizedFields({ fields })).toEqual([
+      {
+        name: "textFieldExtra",
+        type: "text",
+        localized: true,
+      },
+      {
+        name: "textareaFieldExtra",
+        type: "textarea",
+        localized: true,
+      },
+      {
+        fields: [
+          {
+            name: "textField",
+            type: "text",
+            localized: true,
+          },
+          {
+            name: "textareaField",
+            type: "textarea",
+            localized: true,
+          },
+        ],
+        name: "tabTwo",
+        type: "group",
+      },
+      {
+        name: "textField",
+        type: "text",
+        localized: true,
+      },
+      {
+        name: "textareaField",
+        type: "textarea",
+        localized: true,
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Collections/Globals that have an array length of 1 consisting of a top-level [tabs field](https://payloadcms.com/docs/fields/tabs) are ignored due to a weak check on tabs.

Improve tabs field support by parsing all top-level `tabs` fields. Note: nested tabs fields are not supported.

How it works:

- All `Tab` field types without a `name` are converted to a [collapsible field](https://payloadcms.com/docs/fields/collapsible). The `getLocalizedFields` function flattens this field type.
- All `Tab` field types with a `name` field are converted to a [group field](https://payloadcms.com/docs/fields/group) using the tab `name` property for the group `name`. The `getLocalizedFields` function will nest these fields appropriately.
