### PR TITLE
feat(afterdelete): add hook to delete collection article files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [0.13.4](https://github.com/thompsonsj/payload-crowdin-sync/compare/v0.13.3...v0.13.4) (2023-08-16)
 
-
 ### Bug Fixes
 
-* **getlocalizedfields:** support top-level tabs fields ([#92](https://github.com/thompsonsj/payload-crowdin-sync/issues/92)) ([e4cc0c9](https://github.com/thompsonsj/payload-crowdin-sync/commit/e4cc0c9984721270a95aed2b90bf77b866cd7d6c))
+- **getlocalizedfields:** support top-level tabs fields ([#92](https://github.com/thompsonsj/payload-crowdin-sync/issues/92)) ([e4cc0c9](https://github.com/thompsonsj/payload-crowdin-sync/commit/e4cc0c9984721270a95aed2b90bf77b866cd7d6c))
 
 ## [0.13.3](https://github.com/thompsonsj/payload-crowdin-sync/compare/v0.13.2...v0.13.3) (2023-08-12)
 

--- a/dev/src/tests/files.test.ts
+++ b/dev/src/tests/files.test.ts
@@ -241,5 +241,20 @@ describe(`Crowdin file create, update and delete`, () => {
         },
       });
     });
+
+    it("deletes the `fields` file when an existing article is deleted", async () => {
+      const post = await payload.create({
+        collection: collections.localized,
+        data: { title: "Test post" },
+      });
+      const file = await getFileByDocumentID("fields", post.id, payload);
+      expect(file.fileData.json).toEqual({ title: "Test post" });
+      const deletedPost = await payload.delete({
+        collection: collections.localized,
+        id: post.id,
+      });
+      const crowdinFiles = await getFilesByDocumentID(post.id, payload);
+      expect(crowdinFiles.length).toEqual(0);
+    });
   });
 });

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,5 +1,5 @@
 import { Payload } from "payload";
-import { IcrowdinFile } from './payload-crowdin-sync/files'
+import { IcrowdinFile } from "./payload-crowdin-sync/files";
 
 /**
  * get Crowdin Article Directory for a given documentId

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,4 +1,5 @@
 import { Payload } from "payload";
+import { IcrowdinFile } from './payload-crowdin-sync/files'
 
 /**
  * get Crowdin Article Directory for a given documentId
@@ -66,7 +67,7 @@ export async function getFileByDocumentID(
   name: string,
   documentId: string,
   payload: Payload
-): Promise<any> {
+): Promise<IcrowdinFile> {
   const articleDirectory = await getArticleDirectory(documentId, payload);
   return getFile(name, articleDirectory.id, payload);
 }
@@ -74,7 +75,7 @@ export async function getFileByDocumentID(
 export async function getFilesByDocumentID(
   documentId: string,
   payload: Payload
-): Promise<any> {
+): Promise<IcrowdinFile[]> {
   const articleDirectory = await getArticleDirectory(documentId, payload);
   const files = await getFiles(articleDirectory.id, payload);
   return files;

--- a/src/api/payload-crowdin-sync/files.ts
+++ b/src/api/payload-crowdin-sync/files.ts
@@ -16,7 +16,7 @@ import {
 } from "../helpers";
 import { isEmpty } from "lodash";
 
-interface IcrowdinFile {
+export interface IcrowdinFile {
   id: string;
   originalId: number;
 }
@@ -348,7 +348,7 @@ export class payloadCrowdinSyncFilesApi {
     }
   }
 
-  private async deleteFile(crowdinFile: IcrowdinFile) {
+  async deleteFile(crowdinFile: IcrowdinFile) {
     const file = await this.sourceFilesApi.deleteFile(
       this.projectId,
       crowdinFile.originalId

--- a/src/hooks/collections/afterDelete.ts
+++ b/src/hooks/collections/afterDelete.ts
@@ -1,0 +1,35 @@
+import {
+  CollectionAfterDeleteHook,
+} from "payload/types"
+import { payloadCrowdinSyncFilesApi } from "../../api/payload-crowdin-sync/files";
+import { PluginOptions } from "../../types";
+
+interface CommonArgs {
+  pluginOptions: PluginOptions;
+}
+
+interface Args extends CommonArgs {}
+
+export const getAfterDeleteHook = ({ pluginOptions }: Args): CollectionAfterDeleteHook => async ({
+  req, // full express request
+  id, // id of document to delete
+  doc, // deleted document
+}) => {
+  /**
+   * Abort if token not set and not in test mode
+   */
+  if (!pluginOptions.token && process.env.NODE_ENV !== "test") {
+    return doc;
+  }
+
+  /**
+   * Initialize Crowdin client sourceFilesApi
+   */
+  const filesApi = new payloadCrowdinSyncFilesApi(pluginOptions, req.payload);
+
+  const files = await filesApi.getFilesByDocumentID(`${id}`)
+
+  for ( const file of files ) {
+    await filesApi.deleteFile(file)
+  }
+}

--- a/src/hooks/collections/afterDelete.ts
+++ b/src/hooks/collections/afterDelete.ts
@@ -1,6 +1,4 @@
-import {
-  CollectionAfterDeleteHook,
-} from "payload/types"
+import { CollectionAfterDeleteHook } from "payload/types";
 import { payloadCrowdinSyncFilesApi } from "../../api/payload-crowdin-sync/files";
 import { PluginOptions } from "../../types";
 
@@ -10,26 +8,28 @@ interface CommonArgs {
 
 interface Args extends CommonArgs {}
 
-export const getAfterDeleteHook = ({ pluginOptions }: Args): CollectionAfterDeleteHook => async ({
-  req, // full express request
-  id, // id of document to delete
-  doc, // deleted document
-}) => {
-  /**
-   * Abort if token not set and not in test mode
-   */
-  if (!pluginOptions.token && process.env.NODE_ENV !== "test") {
-    return doc;
-  }
+export const getAfterDeleteHook =
+  ({ pluginOptions }: Args): CollectionAfterDeleteHook =>
+  async ({
+    req, // full express request
+    id, // id of document to delete
+    doc, // deleted document
+  }) => {
+    /**
+     * Abort if token not set and not in test mode
+     */
+    if (!pluginOptions.token && process.env.NODE_ENV !== "test") {
+      return doc;
+    }
 
-  /**
-   * Initialize Crowdin client sourceFilesApi
-   */
-  const filesApi = new payloadCrowdinSyncFilesApi(pluginOptions, req.payload);
+    /**
+     * Initialize Crowdin client sourceFilesApi
+     */
+    const filesApi = new payloadCrowdinSyncFilesApi(pluginOptions, req.payload);
 
-  const files = await filesApi.getFilesByDocumentID(`${id}`)
+    const files = await filesApi.getFilesByDocumentID(`${id}`);
 
-  for ( const file of files ) {
-    await filesApi.deleteFile(file)
-  }
-}
+    for (const file of files) {
+      await filesApi.deleteFile(file);
+    }
+  };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,9 +4,7 @@ import {
   getAfterChangeHook,
   getGlobalAfterChangeHook,
 } from "./hooks/collections/afterChange";
-import {
-  getAfterDeleteHook,
-} from "./hooks/collections/afterDelete";
+import { getAfterDeleteHook } from "./hooks/collections/afterDelete";
 import { getFields } from "./fields/getFields";
 import CrowdinFiles from "./collections/CrowdinFiles";
 import CrowdinCollectionDirectories from "./collections/CrowdinCollectionDirectories";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,6 +4,9 @@ import {
   getAfterChangeHook,
   getGlobalAfterChangeHook,
 } from "./hooks/collections/afterChange";
+import {
+  getAfterDeleteHook,
+} from "./hooks/collections/afterDelete";
 import { getFields } from "./fields/getFields";
 import CrowdinFiles from "./collections/CrowdinFiles";
 import CrowdinCollectionDirectories from "./collections/CrowdinCollectionDirectories";
@@ -73,6 +76,12 @@ export const crowdinSync =
                   ...(existingCollection.hooks?.afterChange || []),
                   getAfterChangeHook({
                     collection: existingCollection,
+                    pluginOptions,
+                  }),
+                ],
+                afterDelete: [
+                  ...(existingCollection.hooks?.afterDelete || []),
+                  getAfterDeleteHook({
                     pluginOptions,
                   }),
                 ],


### PR DESCRIPTION
For collections, add an [afterDelete hook](https://payloadcms.com/docs/hooks/collections#afterdelete) that removes all Crowdin files associated with an article.

Note: the corresponding folder on Crowdin is not deleted. This is for a future pull request. We need a test driven developed method for deleting a Crowdin Article Directory in Payload CMS that deletes the corresponding folder on Crowdin. Perhaps it makes sense to wrap the delete files function into this? Or would Crowdin delete all files automatically if we just delete the folder?