### PR TITLE
feat(afterDelete): delete Crowdin article directory on delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [0.14.0](https://github.com/thompsonsj/payload-crowdin-sync/compare/v0.13.4...v0.14.0) (2023-08-16)
 
-
 ### Features
 
-* **afterdelete:** add hook to delete collection article files ([#95](https://github.com/thompsonsj/payload-crowdin-sync/issues/95)) ([0a58adb](https://github.com/thompsonsj/payload-crowdin-sync/commit/0a58adb399f2dda602068bb202fae3cc4a4fc598))
+- **afterdelete:** add hook to delete collection article files ([#95](https://github.com/thompsonsj/payload-crowdin-sync/issues/95)) ([0a58adb](https://github.com/thompsonsj/payload-crowdin-sync/commit/0a58adb399f2dda602068bb202fae3cc4a4fc598))
 
 ## [0.13.4](https://github.com/thompsonsj/payload-crowdin-sync/compare/v0.13.3...v0.13.4) (2023-08-16)
 

--- a/dev/src/tests/files.test.ts
+++ b/dev/src/tests/files.test.ts
@@ -4,6 +4,7 @@ import { initPayloadTest } from "./helpers/config";
 import {
   getFileByDocumentID,
   getFilesByDocumentID,
+  getArticleDirectory,
 } from "../../../dist/api/helpers";
 
 /**
@@ -255,6 +256,21 @@ describe(`Crowdin file create, update and delete`, () => {
       });
       const crowdinFiles = await getFilesByDocumentID(post.id, payload);
       expect(crowdinFiles.length).toEqual(0);
+    });
+
+    it("deletes the collection Crowdin article directory when an existing article is deleted", async () => {
+      const post = await payload.create({
+        collection: collections.localized,
+        data: { title: "Test post" },
+      });
+      const file = await getFileByDocumentID("fields", post.id, payload);
+      expect(file.fileData.json).toEqual({ title: "Test post" });
+      const deletedPost = await payload.delete({
+        collection: collections.localized,
+        id: post.id,
+      });
+      const crowdinPayloadArticleDirectory = await getArticleDirectory(post.id, payload)
+      expect(crowdinPayloadArticleDirectory).toBeUndefined()
     });
   });
 });

--- a/dev/src/tests/files.test.ts
+++ b/dev/src/tests/files.test.ts
@@ -269,8 +269,11 @@ describe(`Crowdin file create, update and delete`, () => {
         collection: collections.localized,
         id: post.id,
       });
-      const crowdinPayloadArticleDirectory = await getArticleDirectory(post.id, payload)
-      expect(crowdinPayloadArticleDirectory).toBeUndefined()
+      const crowdinPayloadArticleDirectory = await getArticleDirectory(
+        post.id,
+        payload
+      );
+      expect(crowdinPayloadArticleDirectory).toBeUndefined();
     });
   });
 });

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -29,7 +29,9 @@ export async function getArticleDirectory(
       "This article does not have a corresponding entry in the  crowdin-article-directories collection."
     );
   }
-  return crowdinPayloadArticleDirectory ? crowdinPayloadArticleDirectory.docs[0] : undefined;
+  return crowdinPayloadArticleDirectory
+    ? crowdinPayloadArticleDirectory.docs[0]
+    : undefined;
 }
 
 export async function getFile(
@@ -80,7 +82,7 @@ export async function getFilesByDocumentID(
   const articleDirectory = await getArticleDirectory(documentId, payload);
   if (!articleDirectory) {
     // tests call this function to make sure files are deleted
-    return []
+    return [];
   }
   const files = await getFiles(articleDirectory.id, payload);
   return files;

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -10,7 +10,8 @@ import { IcrowdinFile } from "./payload-crowdin-sync/files";
  */
 export async function getArticleDirectory(
   documentId: string,
-  payload: Payload
+  payload: Payload,
+  allowEmpty?: boolean
 ) {
   // Get directory
   const crowdinPayloadArticleDirectory = await payload.find({
@@ -21,14 +22,14 @@ export async function getArticleDirectory(
       },
     },
   });
-  if (crowdinPayloadArticleDirectory.totalDocs === 0) {
+  if (crowdinPayloadArticleDirectory.totalDocs === 0 && allowEmpty) {
     // a thrown error won't be reported in an api call, so console.log it as well.
     console.log(`No article directory found for document ${documentId}`);
     throw new Error(
       "This article does not have a corresponding entry in the  crowdin-article-directories collection."
     );
   }
-  return crowdinPayloadArticleDirectory.docs[0];
+  return crowdinPayloadArticleDirectory ? crowdinPayloadArticleDirectory.docs[0] : undefined;
 }
 
 export async function getFile(
@@ -77,6 +78,10 @@ export async function getFilesByDocumentID(
   payload: Payload
 ): Promise<IcrowdinFile[]> {
   const articleDirectory = await getArticleDirectory(documentId, payload);
+  if (!articleDirectory) {
+    // tests call this function to make sure files are deleted
+    return []
+  }
   const files = await getFiles(articleDirectory.id, payload);
   return files;
 }

--- a/src/api/mock/crowdin-client.ts
+++ b/src/api/mock/crowdin-client.ts
@@ -83,6 +83,10 @@ class crowdinAPIWrapper {
     await Promise.resolve(1).then(() => undefined);
   }
 
+  async deleteDirectory(projectId: number, directoryId: number): Promise<void> {
+    await Promise.resolve(1).then(() => undefined);
+  }
+
   async createFile(
     projectId: number,
     {

--- a/src/api/payload-crowdin-sync/files.ts
+++ b/src/api/payload-crowdin-sync/files.ts
@@ -20,9 +20,9 @@ export interface IcrowdinFile {
   id: string;
   originalId: number;
   fileData: {
-    json?: Object
-    html?: string
-  }
+    json?: Object;
+    html?: string;
+  };
 }
 
 interface IfindOrCreateCollectionDirectory {
@@ -427,19 +427,21 @@ export class payloadCrowdinSyncFilesApi {
       await this.deleteFile(file);
     }
 
-    await this.deleteArticleDirectory(documentId)
+    await this.deleteArticleDirectory(documentId);
   }
 
   async deleteArticleDirectory(documentId: string) {
-    const crowdinPayloadArticleDirectory = await this.getArticleDirectory(documentId)
+    const crowdinPayloadArticleDirectory = await this.getArticleDirectory(
+      documentId
+    );
     await this.sourceFilesApi.deleteDirectory(
       this.projectId,
       crowdinPayloadArticleDirectory.originalId
-    )
+    );
     await this.payload.delete({
-      collection: 'crowdin-article-directories',
-      id: crowdinPayloadArticleDirectory.id
-    })
+      collection: "crowdin-article-directories",
+      id: crowdinPayloadArticleDirectory.id,
+    });
   }
 
   async getFileByDocumentID(name: string, documentId: string) {

--- a/src/api/payload-crowdin-sync/files.ts
+++ b/src/api/payload-crowdin-sync/files.ts
@@ -19,6 +19,10 @@ import { isEmpty } from "lodash";
 export interface IcrowdinFile {
   id: string;
   originalId: number;
+  fileData: {
+    json?: Object
+    html?: string
+  }
 }
 
 interface IfindOrCreateCollectionDirectory {
@@ -414,6 +418,28 @@ export class payloadCrowdinSyncFilesApi {
   async getArticleDirectory(documentId: string) {
     const result = await getArticleDirectory(documentId, this.payload);
     return result;
+  }
+
+  async deleteFilesAndDirectory(documentId: string) {
+    const files = await this.getFilesByDocumentID(documentId);
+
+    for (const file of files) {
+      await this.deleteFile(file);
+    }
+
+    await this.deleteArticleDirectory(documentId)
+  }
+
+  async deleteArticleDirectory(documentId: string) {
+    const crowdinPayloadArticleDirectory = await this.getArticleDirectory(documentId)
+    await this.sourceFilesApi.deleteDirectory(
+      this.projectId,
+      crowdinPayloadArticleDirectory.originalId
+    )
+    await this.payload.delete({
+      collection: 'crowdin-article-directories',
+      id: crowdinPayloadArticleDirectory.id
+    })
   }
 
   async getFileByDocumentID(name: string, documentId: string) {

--- a/src/hooks/collections/afterDelete.ts
+++ b/src/hooks/collections/afterDelete.ts
@@ -27,5 +27,5 @@ export const getAfterDeleteHook =
      */
     const filesApi = new payloadCrowdinSyncFilesApi(pluginOptions, req.payload);
 
-    await filesApi.deleteFilesAndDirectory(`${id}`)
+    await filesApi.deleteFilesAndDirectory(`${id}`);
   };

--- a/src/hooks/collections/afterDelete.ts
+++ b/src/hooks/collections/afterDelete.ts
@@ -27,9 +27,5 @@ export const getAfterDeleteHook =
      */
     const filesApi = new payloadCrowdinSyncFilesApi(pluginOptions, req.payload);
 
-    const files = await filesApi.getFilesByDocumentID(`${id}`);
-
-    for (const file of files) {
-      await filesApi.deleteFile(file);
-    }
+    await filesApi.deleteFilesAndDirectory(`${id}`)
   };


### PR DESCRIPTION
Fix https://github.com/thompsonsj/payload-crowdin-sync/issues/96.

Delete the Crowdin article directory when an article in collection is deleted.

Addressing questions in https://github.com/thompsonsj/payload-crowdin-sync/pull/95, the delete file behaviour is retained. It may be that Crowdin deletes containing files when a directory is deleted, but it makes sense to delete files individually before deleting a directory because this is the best place to update the `crowdin-files` collection in Payload CMS.