### PR TITLE
feat(plugin): return original config if no token

### DIFF
--- a/dev/src/payload.config.ts
+++ b/dev/src/payload.config.ts
@@ -35,7 +35,7 @@ export default buildConfig({
     crowdinSync({
       projectId: 323731,
       directoryId: 1169,
-      token: process.env.CROWDIN_TOKEN,
+      token: `fake-token`, // CrowdIn API is mocked but we need a token to pass schema validation
       localeMap,
       sourceLocale: "en",
     }),

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -26,11 +26,6 @@ export const crowdinSync =
   (config: Config): Config => {
     const initFunctions: (() => void)[] = [];
 
-    // do not load anything if token not provided
-    if (!pluginOptions.token) {
-      return config
-    }
-
     // schema validation
     const schema = Joi.object({
       projectId: Joi.number().required(),
@@ -38,7 +33,7 @@ export const crowdinSync =
       directoryId: Joi.number(),
 
       // optional - if not provided, the plugin will not do anything in the afterChange hook.
-      token: Joi.string(),
+      token: Joi.string().required(),
 
       localeMap: Joi.object().pattern(
         /./,
@@ -57,6 +52,7 @@ export const crowdinSync =
         "Payload Crowdin Sync option validation errors:",
         validate.error
       );
+      return config
     }
 
     return {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -26,6 +26,11 @@ export const crowdinSync =
   (config: Config): Config => {
     const initFunctions: (() => void)[] = [];
 
+    // do not load anything if token not provided
+    if (!pluginOptions.token) {
+      return config
+    }
+
     // schema validation
     const schema = Joi.object({
       projectId: Joi.number().required(),


### PR DESCRIPTION
To make it easier to completely disable this plugin in certain environments, return the original Payload CMS config if no CrowdIn token is present.