### PR TITLE
fix(gethtmlfieldslugs): incomplete html field translations

### DIFF
--- a/dev/src/collections/MultiRichText.ts
+++ b/dev/src/collections/MultiRichText.ts
@@ -1,0 +1,9 @@
+import { CollectionConfig } from "payload/types";
+import { multiRichTextFields } from "./fields/multiRichTextFields";
+
+const MultiRichText: CollectionConfig = {
+  slug: "multi-rich-text",
+  fields: multiRichTextFields,
+};
+
+export default MultiRichText;

--- a/dev/src/collections/fields/multiRichTextFields.ts
+++ b/dev/src/collections/fields/multiRichTextFields.ts
@@ -1,0 +1,7 @@
+import { RichTextField } from "payload/types";
+
+export const multiRichTextFields: RichTextField[] = Array(11).fill({}).map((item, index) => ({
+  name: `field_${index}`,
+  type: 'richText',
+  localized: true,
+}))

--- a/dev/src/payload.config.ts
+++ b/dev/src/payload.config.ts
@@ -2,6 +2,7 @@ import { buildConfig } from "payload/config";
 import path from "path";
 import Nav from "./globals/Nav";
 import Categories from "./collections/Categories";
+import MultiRichText from "./collections/MultiRichText";
 import LocalizedPosts from "./collections/LocalizedPosts";
 import Posts from "./collections/Posts";
 import NestedFieldCollection from "./collections/NestedFieldCollection";
@@ -42,6 +43,7 @@ export default buildConfig({
   ],
   collections: [
     Categories,
+    MultiRichText,
     LocalizedPosts,
     NestedFieldCollection,
     Posts,

--- a/dev/src/tests/translations.test.ts
+++ b/dev/src/tests/translations.test.ts
@@ -5,6 +5,7 @@ import { payloadCrowdinSyncTranslationsApi } from "../../../dist/api/payload-cro
 import nock from "nock";
 import { payloadCreateData } from "./fixtures/nested-field-collection/simple-blocks.fixture";
 import { payloadCreateBlocksRichTextData } from "./fixtures/nested-field-collection/rich-text-blocks.fixture";
+import { multiRichTextFields } from "../collections/fields/multiRichTextFields";
 
 /**
  * Test translations
@@ -521,4 +522,49 @@ describe("Translations", () => {
       ]);
     });
   });
+
+  describe('fn: getHtmlFieldSlugs', () => {
+    /**
+     * If Payload queries are not written correctly,
+     * we may end up with the default limit of 10.
+     */
+    it("retrieves all HTML field slugs", async () => {
+      const slug = "multi-rich-text"
+
+      const data = multiRichTextFields.filter(field => field.type === 'richText').reduce((accum, field) => {
+        accum[field.name] = [
+          {
+            children: [
+              {
+                text: `Rich text content for ${field.name}.`,
+              },
+            ],
+          },
+        ];
+        return accum;
+      }, {});
+      const post = await payload.create({
+        collection: slug,
+        data,
+      });
+      const translationsApi = new payloadCrowdinSyncTranslationsApi(
+        pluginOptions,
+        payload
+      );
+      const htmlFieldSlugs = await translationsApi.getHtmlFieldSlugs(post.id);
+      expect(htmlFieldSlugs.sort()).toEqual([
+          "field_0",
+          "field_1",
+          "field_10",
+          "field_2",
+          "field_3",
+          "field_4",
+          "field_5",
+          "field_6",
+          "field_7",
+          "field_8",
+          "field_9",
+        ]);
+    });
+  })
 });

--- a/dev/src/tests/translations.test.ts
+++ b/dev/src/tests/translations.test.ts
@@ -547,11 +547,17 @@ describe("Translations", () => {
         collection: slug,
         data,
       });
+      // ensure all afterChange hooks have run? Getting test failures without this additional operation.
+      const result = await payload.findByID({
+        collection: slug,
+        id: post.id,
+      });
       const translationsApi = new payloadCrowdinSyncTranslationsApi(
         pluginOptions,
         payload
       );
-      const htmlFieldSlugs = await translationsApi.getHtmlFieldSlugs(post.id);
+      const htmlFieldSlugs = await translationsApi.getHtmlFieldSlugs(result.id);
+      expect(htmlFieldSlugs.length).toEqual(11)
       expect(htmlFieldSlugs.sort()).toEqual([
           "field_0",
           "field_1",

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -57,6 +57,7 @@ export async function getFiles(
 ): Promise<any> {
   const result = await payload.find({
     collection: "crowdin-files",
+    limit: 0,
     where: {
       crowdinArticleDirectory: {
         equals: crowdinArticleDirectoryId,

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -57,7 +57,7 @@ export async function getFiles(
 ): Promise<any> {
   const result = await payload.find({
     collection: "crowdin-files",
-    limit: 10000, // Arbitrarily high limit. Is it worth pagination? Unlikely that a collection has a number of fields that justify this.
+    limit: 0,
     where: {
       crowdinArticleDirectory: {
         equals: crowdinArticleDirectoryId,

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -57,7 +57,7 @@ export async function getFiles(
 ): Promise<any> {
   const result = await payload.find({
     collection: "crowdin-files",
-    limit: 0,
+    limit: 10000, // Arbitrarily high limit. Is it worth pagination? Unlikely that a collection has a number of fields that justify this.
     where: {
       crowdinArticleDirectory: {
         equals: crowdinArticleDirectoryId,


### PR DESCRIPTION
If there are more than Crowdin 10 files associated with a given collection/global item, an incomplete set of translations will be retrieved from Crowdin. This is due to a default limit of `10` in the query to retrieve Crowdin HTML file records from Payload CMS. Remove this limit.