### PR TITLE
feat(utilities): expose utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { crowdinSync } from "./plugin";
 import { payloadHtmlToSlateConfig, payloadSlateToHtmlConfig } from '@slate-serializers/html'
+import * as utilities from "./utilities";
 
-export { crowdinSync, payloadHtmlToSlateConfig, payloadSlateToHtmlConfig };
+export { crowdinSync, payloadHtmlToSlateConfig, payloadSlateToHtmlConfig, utilities };


### PR DESCRIPTION
As I'm unable to use the endpoint utilities (https://github.com/thompsonsj/payload-crowdin-sync/issues/111), I'd like to use the functions in utilities directly in my own endpoints.  Therefore I propose to export the `utilities` module from the root module.