### PR TITLE
fix(translations): ensure non-localized blocks/array items are not lost

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -6,13 +6,13 @@
   "private": true,
   "scripts": {
     "dev": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.default.ts nodemon",
-    "build:payload": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload build",
+    "build:payload": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.default.ts payload build",
     "build:server": "tsc",
     "build": "yarn copyfiles && yarn build:payload && yarn build:server",
-    "serve": "cross-env PAYLOAD_CONFIG_PATH=dist/payload.config.js NODE_ENV=production node dist/server.js",
+    "serve": "cross-env PAYLOAD_CONFIG_PATH=dist/payload.default.config.js NODE_ENV=production node dist/server.js",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png}\" dist/",
-    "generate:types": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload generate:types",
-    "generate:graphQLSchema": "PAYLOAD_CONFIG_PATH=src/payload.config.ts payload generate:graphQLSchema"
+    "generate:types": "cross-env PAYLOAD_CONFIG_PATH=src/payload.default.config.ts payload generate:types",
+    "generate:graphQLSchema": "PAYLOAD_CONFIG_PATH=src/payload.default.config.ts payload generate:graphQLSchema"
   },
   "dependencies": {
     "@payloadcms/bundler-webpack": "^1.0.4",

--- a/dev/src/collections/NestedFieldCollection.ts
+++ b/dev/src/collections/NestedFieldCollection.ts
@@ -1,9 +1,15 @@
 import { Block, CollectionConfig } from "payload/types";
 import { basicLocalizedFields } from "./fields/basicLocalizedFields";
+import { delocalizeFields } from "../utils";
 
 const BasicBlockTextFields: Block = {
   slug: "basicBlock", // required
   fields: basicLocalizedFields,
+};
+
+const BasicBlockTextFieldsNonLocalized: Block = {
+  slug: "basicBlockNonLocalized", // required
+  fields: delocalizeFields(basicLocalizedFields),
 };
 
 const BasicBlockRichTextField: Block = {
@@ -76,6 +82,7 @@ const NestedFieldCollection: CollectionConfig = {
       type: "blocks", // required
       blocks: [
         BasicBlockTextFields,
+        BasicBlockTextFieldsNonLocalized,
         BasicBlockRichTextField,
         BasicBlockMixedFields,
         TestBlockArrayOfRichText,

--- a/dev/src/tests/fixtures/nested-field-collection/simple-blocks-with-non-localized-blocks.fixture.ts
+++ b/dev/src/tests/fixtures/nested-field-collection/simple-blocks-with-non-localized-blocks.fixture.ts
@@ -1,0 +1,19 @@
+export const payloadCreateIncludesNonLocalizedBlocksData = {
+  layout: [
+    {
+      textField: "Text field content in block at layout index 0",
+      textareaField: "Textarea field content in block at layout index 0",
+      blockType: "basicBlock",
+    },
+    {
+      textField: "Text field content in block at layout index 1",
+      textareaField: "Textarea field content in block at layout index 1",
+      blockType: "basicBlockNonLocalized",
+    },
+    {
+      textField: "Text field content in block at layout index 2",
+      textareaField: "Textarea field content in block at layout index 2",
+      blockType: "basicBlock",
+    },
+  ],
+};

--- a/dev/src/utils/index.ts
+++ b/dev/src/utils/index.ts
@@ -1,0 +1,16 @@
+import { Field } from 'payload/types';
+import dot from 'dot-object';
+
+export const delocalizeFields = (fields: Field[]): Field[] => {
+  const delocalized = fields.map((field: Field) => {
+    const dotFields = dot.dot(field);
+    const dotKeysNoLocalized = Object.keys(dotFields)
+      .filter(key => !key.endsWith('localized'))
+      .reduce((obj, key) => {
+        obj[key] = dotFields[key];
+        return obj;
+      }, {});
+    return dot.object(dotKeysNoLocalized);
+  })
+  return delocalized as Field[];
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -299,7 +299,10 @@ export const restoreOrder = ({
             }
           );
           if (!arrayItem) {
-            return;
+            return {
+              id: item.id,
+              ...(field.type === "blocks" && { blockType: item.blockType }),
+            };
           }
           const subFields =
             field.type === "blocks"

--- a/src/utilities/tests/inline-snapshots/book-demo.test.ts
+++ b/src/utilities/tests/inline-snapshots/book-demo.test.ts
@@ -249,8 +249,20 @@ describe("book demo collection snapshots", () => {
           "content": {
             "items": [
               {
+                "id": "64a8af5656f68b0022bfd267",
+              },
+              {
                 "id": "64a8af5656f68b0022bfd268",
                 "text": "Offres d'emploi et utilisateurs illimités",
+              },
+              {
+                "id": "64a8af5656f68b0022bfd269",
+              },
+              {
+                "id": "64a8af5656f68b0022bfd26a",
+              },
+              {
+                "id": "64a8af5656f68b0022bfd26b",
               },
               {
                 "id": "64a8af5656f68b0022bfd26c",


### PR DESCRIPTION
For array items or blocks that do not contain localized fields, ensure the minimum data is included in the locale update.

- For the [array field type](https://payloadcms.com/docs/fields/array), include the `id` field for any array items without a localized field.
- For a block in a [blocks field type](https://payloadcms.com/docs/fields/blocks), include both the `id` and `blockType` field.

This takes place in the `restoreOrder` function which is responsible for re-ordering array and block fields to represent the original order of the source locale.

Without this change, translation updates remove blocks that do not contain localized fields - even in the source locale.