### PR TITLE
feat(pluginfields): sync from Crowdin virtual fields

### DIFF
--- a/dev/src/lib/payload.config.collections-option.ts
+++ b/dev/src/lib/payload.config.collections-option.ts
@@ -3,7 +3,7 @@ import { buildConfigWithPluginOptions, localeMap } from "./payload.config";
 export default buildConfigWithPluginOptions({
   projectId: 323731,
   directoryId: 1169,
-  token: `fake-token`, // CrowdIn API is mocked but we need a token to pass schema validation
+  token: process.env['NODE_ENV'] === 'test' ? `fake-token` : ``, // CrowdIn API is mocked but we need a token to pass schema validation
   localeMap,
   sourceLocale: "en",
   collections: [

--- a/dev/src/lib/payload.config.custom-serializers.ts
+++ b/dev/src/lib/payload.config.custom-serializers.ts
@@ -4,7 +4,7 @@ import { payloadHtmlToSlateConfig, payloadSlateToHtmlConfig } from "../../dist";
 export default buildConfigWithPluginOptions({
   projectId: 323731,
   directoryId: 1169,
-  token: `fake-token`, // CrowdIn API is mocked but we need a token to pass schema validation
+  token: process.env['NODE_ENV'] === 'test' ? `fake-token` : ``, // CrowdIn API is mocked but we need a token to pass schema validation
   localeMap,
   sourceLocale: "en",
   slateToHtmlConfig: {

--- a/dev/src/lib/payload.config.default.ts
+++ b/dev/src/lib/payload.config.default.ts
@@ -3,7 +3,8 @@ import { buildConfigWithPluginOptions, localeMap } from "./payload.config";
 export default buildConfigWithPluginOptions({
   projectId: 323731,
   directoryId: 1169,
-  token: `fake-token`, // CrowdIn API is mocked but we need a token to pass schema validation
+  token: process.env['NODE_ENV'] === 'test' ? `fake-token` : ``, // CrowdIn API is mocked but we need a token to pass schema validation
   localeMap,
   sourceLocale: "en",
+  tabbedUI: true,
 });

--- a/dev/src/lib/payload.config.globals-option.ts
+++ b/dev/src/lib/payload.config.globals-option.ts
@@ -3,7 +3,7 @@ import { buildConfigWithPluginOptions, localeMap } from "./payload.config";
 export default buildConfigWithPluginOptions({
   projectId: 323731,
   directoryId: 1169,
-  token: `fake-token`, // CrowdIn API is mocked but we need a token to pass schema validation
+  token: process.env['NODE_ENV'] === 'test' ? `fake-token` : ``, // CrowdIn API is mocked but we need a token to pass schema validation
   localeMap,
   sourceLocale: "en",
   globals: [

--- a/dev/src/lib/tests/collections-collections-option.test.ts
+++ b/dev/src/lib/tests/collections-collections-option.test.ts
@@ -81,6 +81,11 @@ describe("Collections - collections option", () => {
         data,
       });
       // retrieve post to get populated fields
+      await payload.findByID({
+        collection: "multi-rich-text",
+        id: post.id,
+      });
+      // run again - hacky way to wait for all files.
       const result = await payload.findByID({
         collection: "multi-rich-text",
         id: post.id,

--- a/dev/src/lib/tests/collections.test.ts
+++ b/dev/src/lib/tests/collections.test.ts
@@ -159,7 +159,12 @@ describe("Collections", () => {
           ],
         },
       });
-      const crowdinFiles = await getFilesByDocumentID(post.id, payload as any);
+      // hacky way to wait for files to be created
+      await payload.findByID({
+        id: `${post.id}`,
+        collection: "localized-posts"
+      })
+      const crowdinFiles = await getFilesByDocumentID(post.id, payload);
       expect(crowdinFiles.length).toEqual(2);
       const fields = crowdinFiles.find((doc: CrowdinFile) => doc.field === "fields");
       const content = crowdinFiles.find((doc: CrowdinFile) => doc.field === "content");

--- a/plugin/src/lib/endpoints/globals/reviewTranslation.ts
+++ b/plugin/src/lib/endpoints/globals/reviewTranslation.ts
@@ -1,6 +1,6 @@
 import { Endpoint } from "payload/config";
 import { PluginOptions } from "../../types";
-import { payloadCrowdinSyncTranslationsApi } from "../../api/payload-crowdin-sync/translations";
+import { updatePayloadTranslation } from "../../api/helpers";
 
 export const getReviewTranslationEndpoint = ({
   pluginOptions,
@@ -11,31 +11,15 @@ export const getReviewTranslationEndpoint = ({
 }): Endpoint => ({
   path: `/:id/${type}`,
   method: "get",
-  handler: async (req, res, next) => {
-    const articleDirectory = await req.payload.findByID({
-      id: req.params['id'],
-      collection: "crowdin-article-directories",
-    });
-    const global =
-      (articleDirectory['crowdinCollectionDirectory'] as any)?.collectionSlug as string === "globals";
-    const translationsApi = new payloadCrowdinSyncTranslationsApi(
+  handler: async (req, res) => {
+    const update = await updatePayloadTranslation({
+      articleDirectoryId: req.params['id'],
       pluginOptions,
-      req.payload
-    );
-    try {
-      const translations = await translationsApi.updateTranslation({
-        documentId: !global ? articleDirectory["name"] as string : ``,
-        collection: global
-          ? articleDirectory['name'] as string
-          : (articleDirectory["crowdinCollectionDirectory"] as any)?.collectionSlug as string,
-        global,
-        draft: req.query["draft"] === 'true' ? true : false,
-        dryRun: type === "update" ? false : true,
-        excludeLocales: articleDirectory["excludeLocales"] as string[] || [],
-      });
-      res.status(200).send(translations);
-    } catch (error) {
-      res.status(400).send(error);
-    }
+      payload: req.payload,
+      draft: req.query["draft"] === 'true' ? true : false,
+      dryRun: type === "update" ? false : true,
+    })
+    
+    res.status(update.status).send(update);
   },
 });

--- a/plugin/src/lib/fields/documentUI.tsx
+++ b/plugin/src/lib/fields/documentUI.tsx
@@ -1,43 +1,21 @@
-import React, { FC, useEffect, useState } from 'react'
-import type { Props } from 'payload/components/views/Cell'
+import React, { FC } from 'react'
 import { useFormFields } from 'payload/components/forms'
 import { UIField } from 'payload/dist/fields/config/types';
-import { useDocumentInfo, useLocale } from 'payload/components/utilities';
+import { CrowdinArticleDirectory } from '../payload-types';
 
-const baseClass = 'custom-cell'
-
-/**
-export const DocumentCustomUICell: React.FC<Props> = (props) => {
-  const locale = useLocale()
-  const { rowData } = props
-
-  const value = feedback({
-    publishLocales: (rowData.publishLocales || [])  as string[],
-    locale: locale.code,
-    _status: rowData._status as string,
-  })
-
-  return <span className={baseClass}>
-    {value}
-  </span>
-}
-*/
-
-export const DocumentCustomUIField: React.FC<UIField> = (props) => <LocalePublishedFeedback />;
+export const DocumentCustomUIField: React.FC<UIField> = () => <LocalePublishedFeedback />;
 
 const LocalePublishedFeedback: FC = () =>  {
-  const { publishedDoc } = useDocumentInfo()
   const { crowdinArticleDirectory } = useFormFields(([fields]) => {
     return {
-      crowdinArticleDirectory: (fields['crowdinArticleDirectory'].value || []) as any,
+      crowdinArticleDirectory: (fields['crowdinArticleDirectory'].value || []) as CrowdinArticleDirectory,
     }
   });
 
-  useEffect(() => {
-    console.log( publishedDoc, crowdinArticleDirectory )
-  }, [crowdinArticleDirectory]);
-
   return (
-    <input type="text" name="customfield" />
+    <div>
+      <h4>Last sync:</h4>
+      <p>{crowdinArticleDirectory.updatedAt}</p>
+    </div>
   );
 }

--- a/plugin/src/lib/fields/documentUI.tsx
+++ b/plugin/src/lib/fields/documentUI.tsx
@@ -38,6 +38,6 @@ const LocalePublishedFeedback: FC = () =>  {
   }, [crowdinArticleDirectory]);
 
   return (
-    <></>
+    <input type="text" name="customfield" />
   );
 }

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -1,9 +1,10 @@
 import type { Field, TabsField } from "payload/types";
-import { DocumentCustomUIField } from "./documentUI";
+import { updatePayloadTranslation } from "../api/helpers";
+import { PluginOptions } from "../types";
 
 interface Args {
   fields: Field[];
-  tabbedUI?: boolean;
+  pluginOptions: PluginOptions;
 }
 
 const crowdinArticleDirectoryField: Field = {
@@ -17,22 +18,79 @@ const crowdinArticleDirectoryField: Field = {
   },*/
 };
 
-const pluginFields: Field[] = [
-  {
-    name: 'crowdinStatus',
-    type: 'ui',
-    admin: {
-      components: {
-        Field: DocumentCustomUIField,
-        // Cell: PublishedCustomUICell,
+export const pluginCollectionOrGlobalFields = ({
+  fields,
+  pluginOptions,
+}: Args): Field[] => {
+  const pluginFields: Field[] = [
+    {
+      name: 'syncTranslations',
+      type: 'checkbox',
+      access: {
+        create: () => false,
+        // update: () => false,
+      },
+      admin: {
+        description: 'Sync translations for this locale from Crowdin on save draft (stores translations as drafts) or publish (publishes translations).',
+      },
+      hooks: {
+        beforeChange: [async ({ req, siblingData }) => {
+          if (siblingData["syncTranslations"] && siblingData["crowdinArticleDirectory"]) {
+            // is this a draft?
+            const draft = Boolean(siblingData["_status"] && siblingData["_status"] !== 'published')
+            const excludeLocales = Object.keys(pluginOptions.localeMap)
+            const thisLocaleIndex = req.locale && excludeLocales.indexOf(req.locale)
+            if (thisLocaleIndex) {
+              excludeLocales.splice(thisLocaleIndex, 1)
+            }
+
+            await updatePayloadTranslation({
+              articleDirectoryId: typeof siblingData["crowdinArticleDirectory"] === 'string' ? siblingData["crowdinArticleDirectory"] : siblingData["crowdinArticleDirectory"].id,
+              pluginOptions,
+              payload: req.payload,
+              draft,
+              excludeLocales,
+            })
+          }
+          // Mutate the sibling data to prevent DB storage
+          // eslint-disable-next-line no-param-reassign
+          siblingData["syncTranslations"] = undefined;
+        }],
       },
     },
-  },
-  crowdinArticleDirectoryField,
-]
+    {
+      name: 'syncAllTranslations',
+      type: 'checkbox',
+      access: {
+        create: () => false,
+        // update: () => false,
+      },
+      admin: {
+        description: 'Sync all translations from Crowdin on save draft (stores translations as drafts) or publish (publishes translations).',
+      },
+      hooks: {
+        beforeChange: [async ({ siblingData, req }) => {
+          if (siblingData["syncTranslations"] && siblingData["crowdinArticleDirectory"]) {
+            // is this a draft?
+            const draft = Boolean(siblingData["_status"] && siblingData["_status"] !== 'published')
 
-export const pluginCollectionOrGlobalFields = ({ fields, tabbedUI = false }: Args): Field[] => {
-  if (tabbedUI) {
+            await updatePayloadTranslation({
+              articleDirectoryId: typeof siblingData["crowdinArticleDirectory"] === 'string' ? siblingData["crowdinArticleDirectory"] : siblingData["crowdinArticleDirectory"].id,
+              pluginOptions,
+              payload: req.payload,
+              draft,
+            })
+          }
+          // Mutate the sibling data to prevent DB storage
+          // eslint-disable-next-line no-param-reassign
+          siblingData["syncTranslations"] = undefined;
+        }],
+      },
+    },
+    crowdinArticleDirectoryField,
+  ]
+
+  if (pluginOptions.tabbedUI) {
     const pluginTabs: TabsField[] = [
       {
         type: 'tabs',

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -1,6 +1,7 @@
 import type { Field, TabsField } from "payload/types";
 import { updatePayloadTranslation } from "../api/helpers";
 import { PluginOptions } from "../types";
+import { DocumentCustomUIField } from "./documentUI";
 
 interface Args {
   fields: Field[];
@@ -23,6 +24,15 @@ export const pluginCollectionOrGlobalFields = ({
   pluginOptions,
 }: Args): Field[] => {
   const pluginFields: Field[] = [
+    {
+      name: 'lastCrowdinSync',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: DocumentCustomUIField,
+        }
+      }
+    },
     {
       name: 'syncTranslations',
       type: 'checkbox',

--- a/plugin/src/lib/hooks/collections/afterChange.ts
+++ b/plugin/src/lib/hooks/collections/afterChange.ts
@@ -5,6 +5,7 @@ import {
   GlobalConfig,
   GlobalAfterChangeHook,
   PayloadRequest,
+  CollectionBeforeChangeHook,
 } from "payload/types";
 import { Descendant } from "slate";
 import { PluginOptions } from "../../types";

--- a/plugin/src/lib/plugin.ts
+++ b/plugin/src/lib/plugin.ts
@@ -104,7 +104,7 @@ export const crowdinSync =
           })) {
             const fields = pluginCollectionOrGlobalFields({
               fields: existingCollection.fields,
-              tabbedUI: pluginOptions.tabbedUI,
+              pluginOptions,
             });
 
             return {
@@ -200,7 +200,7 @@ export const crowdinSync =
           })) {
             const fields = pluginCollectionOrGlobalFields({
               fields: existingGlobal.fields,
-              tabbedUI: pluginOptions.tabbedUI,
+              pluginOptions,
             });
             return {
               ...existingGlobal,


### PR DESCRIPTION
Create [`checkbox`](https://payloadcms.com/docs/fields/checkbox) virtual fields that can be used to sync translations on save.

- If saving a draft, save translations from Crowdin as draft.
- If publishing, publish translations from Crowdin.

<img width="800" alt="Screenshot 2023-12-15 at 14 19 41" src="https://github.com/thompsonsj/payload-crowdin-sync/assets/44806974/4704b7af-32f9-45f0-b2a3-c07e1cc36352">

## Virtual fields vs UI fields

[Virtual fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges) enable the use of hooks. Updating translations via hooks helps resolve https://github.com/thompsonsj/payload-crowdin-sync/issues/111.

A [UI field](https://payloadcms.com/docs/fields/ui) is also used to read the last translation update date from a `CrowdinArticleDirectory` relationship. These fields are presentational only, so it is not necessary to use virtual fields in this case.