### PR TITLE
fix(payload-types): clashing type names

### DIFF
--- a/dev/src/lib/payload-types.ts
+++ b/dev/src/lib/payload-types.ts
@@ -102,32 +102,42 @@ export interface CrowdinArticleDirectory {
   name?: string | null;
   crowdinCollectionDirectory?: (string | null) | CrowdinCollectionDirectory;
   crowdinFiles?: (string | CrowdinFile)[] | null;
-  createdAt: string;
-  updatedAt: string;
+  reference?: {
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    projectId?: number | null;
+  };
   originalId?: number | null;
-  projectId?: number | null;
   directoryId?: number | null;
+  updatedAt: string;
+  createdAt: string;
 }
 export interface CrowdinCollectionDirectory {
   id: string;
   name?: string | null;
   title?: string | null;
   collectionSlug?: string | null;
-  createdAt: string;
-  updatedAt: string;
+  reference?: {
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    projectId?: number | null;
+  };
   originalId?: number | null;
-  projectId?: number | null;
   directoryId?: number | null;
+  updatedAt: string;
+  createdAt: string;
 }
 export interface CrowdinFile {
   id: string;
   title?: string | null;
   field?: string | null;
   crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
-  createdAt: string;
-  updatedAt: string;
+  reference?: {
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    projectId?: number | null;
+  };
   originalId?: number | null;
-  projectId?: number | null;
   directoryId?: number | null;
   revisionId?: number | null;
   name?: string | null;
@@ -145,6 +155,8 @@ export interface CrowdinFile {
       | null;
     html?: string | null;
   };
+  updatedAt: string;
+  createdAt: string;
 }
 export interface LocalizedPost {
   id: string;

--- a/plugin/src/lib/api/payload-crowdin-sync/files.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files.ts
@@ -128,11 +128,13 @@ export class payloadCrowdinSyncFilesApi {
         data: {
           crowdinCollectionDirectory: crowdinPayloadCollectionDirectory.id,
           originalId: crowdinDirectory.data.id,
-          projectId: this.projectId,
           directoryId: crowdinDirectory.data.directoryId,
           name: crowdinDirectory.data.name,
-          createdAt: crowdinDirectory.data.createdAt,
-          updatedAt: crowdinDirectory.data.updatedAt,
+          reference: {
+            createdAt: crowdinDirectory.data.createdAt,
+            updatedAt: crowdinDirectory.data.updatedAt,
+            projectId: this.projectId,
+          }
         },
       });
 
@@ -189,12 +191,15 @@ export class payloadCrowdinSyncFilesApi {
         data: {
           collectionSlug: collectionSlug,
           originalId: crowdinDirectory.data.id,
-          projectId: this.projectId,
+          
           directoryId: crowdinDirectory.data.directoryId,
           name: crowdinDirectory.data.name,
           title: crowdinDirectory.data.title,
-          createdAt: crowdinDirectory.data.createdAt,
-          updatedAt: crowdinDirectory.data.updatedAt,
+          reference: {
+            createdAt: crowdinDirectory.data.createdAt,
+            updatedAt: crowdinDirectory.data.updatedAt,
+            projectId: this.projectId,
+          }
         },
       });
     } else {
@@ -329,10 +334,12 @@ export class payloadCrowdinSyncFilesApi {
           title: crowdinFile.data.name,
           field: name,
           crowdinArticleDirectory: articleDirectory.id,
-          createdAt: crowdinFile.data.createdAt,
-          updatedAt: crowdinFile.data.updatedAt,
+          reference: {
+            createdAt: crowdinFile.data.createdAt,
+            updatedAt: crowdinFile.data.updatedAt,
+            projectId: crowdinFile.data.projectId,
+          },
           originalId: crowdinFile.data.id,
-          projectId: crowdinFile.data.projectId,
           directoryId: crowdinFile.data.directoryId,
           revisionId: crowdinFile.data.revisionId,
           name: crowdinFile.data.name,

--- a/plugin/src/lib/collections/CrowdinArticleDirectories.ts
+++ b/plugin/src/lib/collections/CrowdinArticleDirectories.ts
@@ -45,28 +45,35 @@ const CrowdinArticleDirectories: CollectionConfig = {
     },
     /* Crowdin fields */
     {
-      name: "createdAt",
-      type: "date",
-      admin: {
-        readOnly: true,
-      }
-    },
-    {
-      name: "updatedAt",
-      type: "date",
-      admin: {
-        readOnly: true,
-      }
+      type: "group",
+       /* For reference only - unused */
+      name: "reference",
+      fields: [
+        {
+          name: "createdAt",
+          type: "date",
+          admin: {
+            readOnly: true,
+          }
+        },
+        {
+          name: "updatedAt",
+          type: "date",
+          admin: {
+            readOnly: true,
+          }
+        },
+        {
+          name: "projectId",
+          type: "number",
+          admin: {
+            readOnly: true,
+          }
+        },
+      ]
     },
     {
       name: "originalId",
-      type: "number",
-      admin: {
-        readOnly: true,
-      }
-    },
-    {
-      name: "projectId",
       type: "number",
       admin: {
         readOnly: true,

--- a/plugin/src/lib/collections/CrowdinCollectionDirectories.ts
+++ b/plugin/src/lib/collections/CrowdinCollectionDirectories.ts
@@ -28,21 +28,29 @@ const CrowdinCollectionDirectories: CollectionConfig = {
 
     /* Crowdin fields */
     {
-      name: "createdAt",
-      type: "date",
-    },
-    {
-      name: "updatedAt",
-      type: "date",
+      type: "group",
+       /* For reference only - unused */
+      name: "reference",
+      fields: [
+        {
+          name: "createdAt",
+          type: "date",
+        },
+        {
+          name: "updatedAt",
+          type: "date",
+        },
+        {
+          name: "projectId",
+          type: "number",
+        },
+      ],
     },
     {
       name: "originalId",
       type: "number",
     },
-    {
-      name: "projectId",
-      type: "number",
-    },
+    
     {
       name: "directoryId",
       type: "number",

--- a/plugin/src/lib/collections/CrowdinFiles.ts
+++ b/plugin/src/lib/collections/CrowdinFiles.ts
@@ -60,19 +60,26 @@ const CrowdinFiles: CollectionConfig = {
     },
     /* Crowdin fields */
     {
-      name: "createdAt",
-      type: "date",
-    },
-    {
-      name: "updatedAt",
-      type: "date",
+      type: "group",
+       /* For reference only - unused */
+      name: "reference",
+      fields: [
+        {
+          name: "createdAt",
+          type: "date",
+        },
+        {
+          name: "updatedAt",
+          type: "date",
+        },
+        {
+          name: "projectId",
+          type: "number",
+        },
+      ],
     },
     {
       name: "originalId",
-      type: "number",
-    },
-    {
-      name: "projectId",
       type: "number",
     },
     {


### PR DESCRIPTION
Getting the following error in Payload CMS 2.4.0:

```
DuplicateFieldName: A field with the name 'updatedAt' was found multiple times on the same level. Field names must be unique.
    at /<project-dir>/node_modules/payload/dist/fields/config/sanitize.js:81:23
```