### PR TITLE
feat(document): send Lexical blocks for translation

### DIFF
--- a/dev/src/lib/collections/fields/lexicalEditorWithBlocks.ts
+++ b/dev/src/lib/collections/fields/lexicalEditorWithBlocks.ts
@@ -22,12 +22,10 @@ export const lexicalEditorWithBlocks: RichTextField = {
                   {
                     name: 'title',
                     type: 'text',
-                    localized: true,
                   },
                   {
                     name: 'preTitle',
                     type: 'text',
-                    localized: true,
                   },
                 ]
               },
@@ -63,12 +61,10 @@ export const lexicalEditorWithBlocks: RichTextField = {
               {
                 name: "text",
                 type: "text",
-                localized: true,
               },
               {
                 name: "href",
                 type: "text",
-                localized: true,
               },
               {
                 name: "type",
@@ -87,12 +83,10 @@ export const lexicalEditorWithBlocks: RichTextField = {
               {
                 name: "title",
                 type: "text",
-                localized: true,
               },
               {
                 name: "content",
                 type: "richText",
-                localized: true,
               },
               {
                 name: "image",

--- a/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
@@ -671,7 +671,7 @@ describe('Lexical editor with blocks', () => {
     const ids = arrayField.map((item) => item.id) || ([] as string[]);
 
     const crowdinFiles = await getFilesByDocumentID(`${policy.id}`, payload);
-    expect(crowdinFiles.length).toEqual(3);
+    expect(crowdinFiles.length).toEqual(7);
 
     const htmlFileOne = crowdinFiles.find(
       (file) => file.name === `group.array.${ids[0]}.content.html`

--- a/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
@@ -39,10 +39,10 @@ describe('Lexical editor with blocks', () => {
       .twice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({
@@ -302,10 +302,10 @@ describe('Lexical editor with blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({
@@ -332,10 +332,10 @@ describe('Lexical editor with blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({
@@ -606,10 +606,10 @@ describe('Lexical editor with blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({
@@ -641,10 +641,10 @@ describe('Lexical editor with blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .thrice()
+      .times(7)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .thrice()
+      .times(7)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.fixture.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.fixture.ts
@@ -1,3 +1,5 @@
+import { Policy } from "../../payload-types"
+
 export const fixture = {
   "root": {
       "type": "root",
@@ -175,43 +177,7 @@ export const fixture = {
                   "blockName": "",
                   "blockType": "imageText",
                   "title": "Testing a range of fields",
-                  "image": {
-                      "id": "65d67e6a7fb7e9426b3f9f5f",
-                      "filename": "phone-icon-small.png",
-                      "mimeType": "image/png",
-                      "filesize": 11150,
-                      "width": 80,
-                      "height": 80,
-                      "sizes": {
-                          "thumbnail": {
-                              "width": null,
-                              "height": null,
-                              "mimeType": null,
-                              "filesize": null,
-                              "filename": null,
-                              "url": null
-                          },
-                          "card": {
-                              "width": null,
-                              "height": null,
-                              "mimeType": null,
-                              "filesize": null,
-                              "filename": null,
-                              "url": null
-                          },
-                          "tablet": {
-                              "width": 1024,
-                              "height": 1024,
-                              "mimeType": "image/png",
-                              "filesize": 241498,
-                              "filename": "phone-icon-small-1024x1024.png",
-                              "url": "http://localhost:3000/media/phone-icon-small-1024x1024.png"
-                          }
-                      },
-                      "createdAt": "2024-02-21T22:51:22.836Z",
-                      "updatedAt": "2024-02-21T22:51:22.836Z",
-                      "url": "http://localhost:3000/media/phone-icon-small.png"
-                  }
+                  "image": "65d67e6a7fb7e9426b3f9f5f",
               }
           },
           {
@@ -238,4 +204,4 @@ export const fixture = {
       ],
       "direction": "ltr"
   }
-}
+} as Policy['content']

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -624,7 +624,7 @@ describe('Lexical editor with multiple blocks', () => {
     `);
   });
 
-  it('creates an HTML file for Crowdin as expected', async () => {
+  it('creates HTML files for Crowdin as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
@@ -651,11 +651,20 @@ describe('Lexical editor with multiple blocks', () => {
       },
     });
     const crowdinFiles = await getFilesByDocumentID(policy.id, payload);
+    console.log(crowdinFiles);
     const contentHtmlFile = crowdinFiles.find(
       (file) => file.field === 'content'
     );
     expect(contentHtmlFile?.fileData?.html).toMatchInlineSnapshot(
       `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span>unknown node</span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span>unknown node</span><span>unknown node</span><ul class="bullet"><li value=1></li></ul>"`
+    );
+    const contentBlocksHtmlFile = crowdinFiles.find(
+      (file) =>
+        file.field?.endsWith('.highlight.content') &&
+        file.field?.startsWith('content--blocks.')
+    );
+    expect(contentBlocksHtmlFile?.fileData?.html).toMatchInlineSnapshot(
+      `"<p>The plugin parses your block configuration for the Lexical rich text editor. It extracts all block values from the rich text field and then treats this config/data combination as a regular \`blocks\` field.</p><p>Markers are placed in the html and this content is restored into the correct place on translation.</p>"`
     );
   });
 

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -125,7 +125,7 @@ describe('Lexical editor with multiple blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
       .times(4)
       .reply(200, mockClient.createFile({}));
-    console.log(fixture);
+
     const policy = await payload.create({
       collection: 'policies',
       data: {
@@ -694,7 +694,7 @@ describe('Lexical editor with multiple blocks', () => {
     const ids = arrayField.map((item) => item.id) || ([] as string[]);
 
     const crowdinFiles = await getFilesByDocumentID(`${policy.id}`, payload);
-    expect(crowdinFiles.length).toEqual(3);
+    expect(crowdinFiles.length).toEqual(7);
 
     const htmlFileOne = crowdinFiles.find(
       (file) => file.name === `group.array.${ids[0]}.content.html`

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -120,10 +120,10 @@ describe('Lexical editor with multiple blocks', () => {
       .twice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
     console.log(fixture);
     const policy = await payload.create({
@@ -354,10 +354,10 @@ describe('Lexical editor with multiple blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({
@@ -384,10 +384,10 @@ describe('Lexical editor with multiple blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({
@@ -629,10 +629,10 @@ describe('Lexical editor with multiple blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({
@@ -664,10 +664,10 @@ describe('Lexical editor with multiple blocks', () => {
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
-      .thrice()
+      .times(7)
       .reply(200, mockClient.addStorage())
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
-      .thrice()
+      .times(7)
       .reply(200, mockClient.createFile({}));
 
     const policy = await payload.create({

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -651,7 +651,6 @@ describe('Lexical editor with multiple blocks', () => {
       },
     });
     const crowdinFiles = await getFilesByDocumentID(policy.id, payload);
-    console.log(crowdinFiles);
     const contentHtmlFile = crowdinFiles.find(
       (file) => file.field === 'content'
     );

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -1,8 +1,15 @@
 import payload from 'payload';
 import { initPayloadTest } from '../helpers/config';
+import { getFilesByDocumentID, isDefined, utilities } from 'plugin';
+import Policies from '../../collections/Policies';
 import { fixture } from './lexical-editor-with-multiple-blocks.fixture';
 import nock from 'nock';
 import { extractLexicalBlockContent } from 'plugin/src/lib/utilities/lexical';
+import { mockCrowdinClient } from 'plugin/src/lib/api/mock/crowdin-api-responses';
+import { pluginConfig } from '../helpers/plugin-config';
+
+const pluginOptions = pluginConfig();
+const mockClient = mockCrowdinClient(pluginOptions);
 
 describe('Lexical editor with multiple blocks', () => {
   beforeAll(async () => {
@@ -28,7 +35,7 @@ describe('Lexical editor with multiple blocks', () => {
   });
 
   it('extracts blocks into a format expected for a "blocks" field', async () => {
-    expect(extractLexicalBlockContent(fixture.root as any))
+    expect(fixture && extractLexicalBlockContent(fixture.root))
       .toMatchInlineSnapshot(`
       [
         {
@@ -100,46 +107,614 @@ describe('Lexical editor with multiple blocks', () => {
           "blockName": "",
           "blockType": "imageText",
           "id": "65d67e2291c92e447e7472f9",
-          "image": {
-            "createdAt": "2024-02-21T22:51:22.836Z",
-            "filename": "phone-icon-small.png",
-            "filesize": 11150,
-            "height": 80,
-            "id": "65d67e6a7fb7e9426b3f9f5f",
-            "mimeType": "image/png",
-            "sizes": {
-              "card": {
-                "filename": null,
-                "filesize": null,
-                "height": null,
-                "mimeType": null,
-                "url": null,
-                "width": null,
-              },
-              "tablet": {
-                "filename": "phone-icon-small-1024x1024.png",
-                "filesize": 241498,
-                "height": 1024,
-                "mimeType": "image/png",
-                "url": "http://localhost:3000/media/phone-icon-small-1024x1024.png",
-                "width": 1024,
-              },
-              "thumbnail": {
-                "filename": null,
-                "filesize": null,
-                "height": null,
-                "mimeType": null,
-                "url": null,
-                "width": null,
-              },
-            },
-            "updatedAt": "2024-02-21T22:51:22.836Z",
-            "url": "http://localhost:3000/media/phone-icon-small.png",
-            "width": 80,
-          },
+          "image": "65d67e6a7fb7e9426b3f9f5f",
           "title": "Testing a range of fields",
         },
       ]
     `);
+  });
+
+  it('builds a Crowdin HTML object as expected', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .twice()
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .twice()
+      .reply(200, mockClient.addStorage())
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .twice()
+      .reply(200, mockClient.createFile({}));
+    console.log(fixture);
+    const policy = await payload.create({
+      collection: 'policies',
+      data: {
+        title: 'Test policy',
+        content: fixture,
+      },
+    });
+    expect(
+      utilities.buildCrowdinHtmlObject({
+        doc: policy,
+        fields: Policies.fields,
+      })
+    ).toMatchInlineSnapshot(`
+      {
+        "content": {
+          "root": {
+            "children": [
+              {
+                "children": [
+                  {
+                    "detail": 0,
+                    "format": 0,
+                    "mode": "normal",
+                    "style": "",
+                    "text": "Sample content for a Lexical rich text field with multiple blocks.",
+                    "type": "text",
+                    "version": 1,
+                  },
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1,
+              },
+              {
+                "fields": {
+                  "blockName": "",
+                  "blockType": "cta",
+                  "href": "https://www.npmjs.com/package/payload-crowdin-sync",
+                  "id": "65d67d2591c92e447e7472f7",
+                  "text": "Download payload-crowdin-sync on npm!",
+                  "type": "primary",
+                },
+                "format": "",
+                "type": "block",
+                "version": 2,
+              },
+              {
+                "children": [
+                  {
+                    "detail": 0,
+                    "format": 0,
+                    "mode": "normal",
+                    "style": "",
+                    "text": "A bulleted list in-between some blocks consisting of:",
+                    "type": "text",
+                    "version": 1,
+                  },
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1,
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "one bullet list item; and",
+                        "type": "text",
+                        "version": 1,
+                      },
+                    ],
+                    "direction": "ltr",
+                    "format": "",
+                    "indent": 0,
+                    "type": "listitem",
+                    "value": 1,
+                    "version": 1,
+                  },
+                  {
+                    "children": [
+                      {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "another!",
+                        "type": "text",
+                        "version": 1,
+                      },
+                    ],
+                    "direction": "ltr",
+                    "format": "",
+                    "indent": 0,
+                    "type": "listitem",
+                    "value": 2,
+                    "version": 1,
+                  },
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "listType": "bullet",
+                "start": 1,
+                "tag": "ul",
+                "type": "list",
+                "version": 1,
+              },
+              {
+                "fields": {
+                  "blockName": "",
+                  "blockType": "highlight",
+                  "color": "green",
+                  "content": {
+                    "root": {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "detail": 0,
+                              "format": 0,
+                              "mode": "normal",
+                              "style": "",
+                              "text": "The plugin parses your block configuration for the Lexical rich text editor. It extracts all block values from the rich text field and then treats this config/data combination as a regular \`blocks\` field.",
+                              "type": "text",
+                              "version": 1,
+                            },
+                          ],
+                          "direction": "ltr",
+                          "format": "",
+                          "indent": 0,
+                          "type": "paragraph",
+                          "version": 1,
+                        },
+                        {
+                          "children": [
+                            {
+                              "detail": 0,
+                              "format": 0,
+                              "mode": "normal",
+                              "style": "",
+                              "text": "Markers are placed in the html and this content is restored into the correct place on translation.",
+                              "type": "text",
+                              "version": 1,
+                            },
+                          ],
+                          "direction": "ltr",
+                          "format": "",
+                          "indent": 0,
+                          "type": "paragraph",
+                          "version": 1,
+                        },
+                      ],
+                      "direction": "ltr",
+                      "format": "",
+                      "indent": 0,
+                      "type": "root",
+                      "version": 1,
+                    },
+                  },
+                  "heading": {
+                    "preTitle": "How the plugin handles blocks in the Lexical editor",
+                    "title": "Blocks are extracted into their own fields",
+                  },
+                  "id": "65d67d8191c92e447e7472f8",
+                },
+                "format": "",
+                "type": "block",
+                "version": 2,
+              },
+              {
+                "fields": {
+                  "blockName": "",
+                  "blockType": "imageText",
+                  "id": "65d67e2291c92e447e7472f9",
+                  "image": "65d67e6a7fb7e9426b3f9f5f",
+                  "title": "Testing a range of fields",
+                },
+                "format": "",
+                "type": "block",
+                "version": 2,
+              },
+              {
+                "children": [
+                  {
+                    "children": [],
+                    "direction": null,
+                    "format": "",
+                    "indent": 0,
+                    "type": "listitem",
+                    "value": 1,
+                    "version": 1,
+                  },
+                ],
+                "direction": null,
+                "format": "",
+                "indent": 0,
+                "listType": "bullet",
+                "start": 1,
+                "tag": "ul",
+                "type": "list",
+                "version": 1,
+              },
+            ],
+            "direction": "ltr",
+            "format": "",
+            "indent": 0,
+            "type": "root",
+            "version": 1,
+          },
+        },
+      }
+    `);
+  });
+
+  it('builds a Crowdin JSON object as expected', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .twice()
+      .reply(200, mockClient.addStorage())
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .twice()
+      .reply(200, mockClient.createFile({}));
+
+    const policy = await payload.create({
+      collection: 'policies',
+      data: {
+        title: 'Test policy',
+        content: fixture,
+      },
+    });
+    expect(
+      utilities.buildCrowdinJsonObject({
+        doc: policy,
+        fields: Policies.fields,
+      })
+    ).toMatchInlineSnapshot(`
+      {
+        "title": "Test policy",
+      }
+    `);
+  });
+
+  it('builds a Payload update object as expected', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .twice()
+      .reply(200, mockClient.addStorage())
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .twice()
+      .reply(200, mockClient.createFile({}));
+
+    const policy = await payload.create({
+      collection: 'policies',
+      data: {
+        title: 'Test policy',
+        content: fixture,
+      },
+    });
+    const crowdinHtmlObject = utilities.buildCrowdinHtmlObject({
+      doc: policy,
+      fields: Policies.fields,
+    });
+    const crowdinJsonObject = utilities.buildCrowdinJsonObject({
+      doc: policy,
+      fields: Policies.fields,
+    });
+    expect(
+      utilities.buildPayloadUpdateObject({
+        crowdinJsonObject,
+        crowdinHtmlObject,
+        fields: Policies.fields,
+        document: policy,
+      })
+    ).toMatchInlineSnapshot(`
+      {
+        "content": {
+          "root": {
+            "children": [
+              {
+                "children": [
+                  {
+                    "detail": 0,
+                    "format": 0,
+                    "mode": "normal",
+                    "style": "",
+                    "text": "Sample content for a Lexical rich text field with multiple blocks.",
+                    "type": "text",
+                    "version": 1,
+                  },
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1,
+              },
+              {
+                "fields": {
+                  "blockName": "",
+                  "blockType": "cta",
+                  "href": "https://www.npmjs.com/package/payload-crowdin-sync",
+                  "id": "65d67d2591c92e447e7472f7",
+                  "text": "Download payload-crowdin-sync on npm!",
+                  "type": "primary",
+                },
+                "format": "",
+                "type": "block",
+                "version": 2,
+              },
+              {
+                "children": [
+                  {
+                    "detail": 0,
+                    "format": 0,
+                    "mode": "normal",
+                    "style": "",
+                    "text": "A bulleted list in-between some blocks consisting of:",
+                    "type": "text",
+                    "version": 1,
+                  },
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1,
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "one bullet list item; and",
+                        "type": "text",
+                        "version": 1,
+                      },
+                    ],
+                    "direction": "ltr",
+                    "format": "",
+                    "indent": 0,
+                    "type": "listitem",
+                    "value": 1,
+                    "version": 1,
+                  },
+                  {
+                    "children": [
+                      {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "another!",
+                        "type": "text",
+                        "version": 1,
+                      },
+                    ],
+                    "direction": "ltr",
+                    "format": "",
+                    "indent": 0,
+                    "type": "listitem",
+                    "value": 2,
+                    "version": 1,
+                  },
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "listType": "bullet",
+                "start": 1,
+                "tag": "ul",
+                "type": "list",
+                "version": 1,
+              },
+              {
+                "fields": {
+                  "blockName": "",
+                  "blockType": "highlight",
+                  "color": "green",
+                  "content": {
+                    "root": {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "detail": 0,
+                              "format": 0,
+                              "mode": "normal",
+                              "style": "",
+                              "text": "The plugin parses your block configuration for the Lexical rich text editor. It extracts all block values from the rich text field and then treats this config/data combination as a regular \`blocks\` field.",
+                              "type": "text",
+                              "version": 1,
+                            },
+                          ],
+                          "direction": "ltr",
+                          "format": "",
+                          "indent": 0,
+                          "type": "paragraph",
+                          "version": 1,
+                        },
+                        {
+                          "children": [
+                            {
+                              "detail": 0,
+                              "format": 0,
+                              "mode": "normal",
+                              "style": "",
+                              "text": "Markers are placed in the html and this content is restored into the correct place on translation.",
+                              "type": "text",
+                              "version": 1,
+                            },
+                          ],
+                          "direction": "ltr",
+                          "format": "",
+                          "indent": 0,
+                          "type": "paragraph",
+                          "version": 1,
+                        },
+                      ],
+                      "direction": "ltr",
+                      "format": "",
+                      "indent": 0,
+                      "type": "root",
+                      "version": 1,
+                    },
+                  },
+                  "heading": {
+                    "preTitle": "How the plugin handles blocks in the Lexical editor",
+                    "title": "Blocks are extracted into their own fields",
+                  },
+                  "id": "65d67d8191c92e447e7472f8",
+                },
+                "format": "",
+                "type": "block",
+                "version": 2,
+              },
+              {
+                "fields": {
+                  "blockName": "",
+                  "blockType": "imageText",
+                  "id": "65d67e2291c92e447e7472f9",
+                  "image": "65d67e6a7fb7e9426b3f9f5f",
+                  "title": "Testing a range of fields",
+                },
+                "format": "",
+                "type": "block",
+                "version": 2,
+              },
+              {
+                "children": [
+                  {
+                    "children": [],
+                    "direction": null,
+                    "format": "",
+                    "indent": 0,
+                    "type": "listitem",
+                    "value": 1,
+                    "version": 1,
+                  },
+                ],
+                "direction": null,
+                "format": "",
+                "indent": 0,
+                "listType": "bullet",
+                "start": 1,
+                "tag": "ul",
+                "type": "list",
+                "version": 1,
+              },
+            ],
+            "direction": "ltr",
+            "format": "",
+            "indent": 0,
+            "type": "root",
+            "version": 1,
+          },
+        },
+        "title": "Test policy",
+      }
+    `);
+  });
+
+  it('creates an HTML file for Crowdin as expected', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .twice()
+      .reply(200, mockClient.addStorage())
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .twice()
+      .reply(200, mockClient.createFile({}));
+
+    const policy = await payload.create({
+      collection: 'policies',
+      data: {
+        title: 'Test policy',
+        content: fixture,
+      },
+    });
+    // update now that a Crowdin article directory is available
+    await payload.update({
+      id: policy.id,
+      collection: 'policies',
+      data: {
+        title: 'Test policy',
+      },
+    });
+    const crowdinFiles = await getFilesByDocumentID(policy.id, payload);
+    const contentHtmlFile = crowdinFiles.find(
+      (file) => file.field === 'content'
+    );
+    expect(contentHtmlFile?.fileData?.html).toMatchInlineSnapshot(
+      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span>unknown node</span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span>unknown node</span><span>unknown node</span><ul class="bullet"><li value=1></li></ul>"`
+    );
+  });
+
+  it('creates HTML files for Crowdin as expected for lexical content within an array field that is embedded in a group', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .thrice()
+      .reply(200, mockClient.addStorage())
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .thrice()
+      .reply(200, mockClient.createFile({}));
+
+    const policy = await payload.create({
+      collection: 'policies',
+      data: {
+        group: {
+          array: [
+            {
+              title: 'Test sub-policy 1',
+              content: fixture,
+            },
+            {
+              title: 'Test sub-policy 2',
+              content: fixture,
+            },
+          ],
+        },
+      },
+    });
+
+    const arrayField = isDefined(policy['group']?.['array'])
+      ? policy['group']?.['array']
+      : [];
+    const ids = arrayField.map((item) => item.id) || ([] as string[]);
+
+    const crowdinFiles = await getFilesByDocumentID(`${policy.id}`, payload);
+    expect(crowdinFiles.length).toEqual(3);
+
+    const htmlFileOne = crowdinFiles.find(
+      (file) => file.name === `group.array.${ids[0]}.content.html`
+    );
+    const htmlFileTwo = crowdinFiles.find(
+      (file) => file.name === `group.array.${ids[1]}.content.html`
+    );
+
+    expect(htmlFileOne).toBeDefined();
+    expect(htmlFileTwo).toBeDefined();
+    expect(
+      crowdinFiles.find((file) => file.name === 'fields.json')
+    ).toBeDefined();
+
+    expect(htmlFileOne?.fileData?.html).toMatchInlineSnapshot(
+      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span>unknown node</span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span>unknown node</span><span>unknown node</span><ul class="bullet"><li value=1></li></ul>"`
+    );
+
+    expect(htmlFileTwo?.fileData?.html).toMatchInlineSnapshot(
+      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span>unknown node</span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span>unknown node</span><span>unknown node</span><ul class="bullet"><li value=1></li></ul>"`
+    );
   });
 });

--- a/dev/src/lib/tests/plugin/getLocalizedFields.test.ts
+++ b/dev/src/lib/tests/plugin/getLocalizedFields.test.ts
@@ -37,12 +37,10 @@ describe('payload-crowdin-sync: getLexicalBlockFields', () => {
               {
                 "fields": [
                   {
-                    "localized": true,
                     "name": "title",
                     "type": "text",
                   },
                   {
-                    "localized": true,
                     "name": "preTitle",
                     "type": "text",
                   },
@@ -380,12 +378,10 @@ describe('payload-crowdin-sync: getLexicalBlockFields', () => {
           {
             "fields": [
               {
-                "localized": true,
                 "name": "text",
                 "type": "text",
               },
               {
-                "localized": true,
                 "name": "href",
                 "type": "text",
               },
@@ -430,12 +426,10 @@ describe('payload-crowdin-sync: getLexicalBlockFields', () => {
           {
             "fields": [
               {
-                "localized": true,
                 "name": "title",
                 "type": "text",
               },
               {
-                "localized": true,
                 "name": "content",
                 "type": "richText",
               },
@@ -1430,12 +1424,10 @@ describe('payload-crowdin-sync: getLocalizedFields', () => {
                           {
                             "fields": [
                               {
-                                "localized": true,
                                 "name": "title",
                                 "type": "text",
                               },
                               {
-                                "localized": true,
                                 "name": "preTitle",
                                 "type": "text",
                               },
@@ -1773,12 +1765,10 @@ describe('payload-crowdin-sync: getLocalizedFields', () => {
                       {
                         "fields": [
                           {
-                            "localized": true,
                             "name": "text",
                             "type": "text",
                           },
                           {
-                            "localized": true,
                             "name": "href",
                             "type": "text",
                           },
@@ -1823,12 +1813,10 @@ describe('payload-crowdin-sync: getLocalizedFields', () => {
                       {
                         "fields": [
                           {
-                            "localized": true,
                             "name": "title",
                             "type": "text",
                           },
                           {
-                            "localized": true,
                             "name": "content",
                             "type": "richText",
                           },
@@ -4156,12 +4144,10 @@ describe('payload-crowdin-sync: getLocalizedFields', () => {
                                   {
                                     "fields": [
                                       {
-                                        "localized": true,
                                         "name": "title",
                                         "type": "text",
                                       },
                                       {
-                                        "localized": true,
                                         "name": "preTitle",
                                         "type": "text",
                                       },
@@ -4499,12 +4485,10 @@ describe('payload-crowdin-sync: getLocalizedFields', () => {
                               {
                                 "fields": [
                                   {
-                                    "localized": true,
                                     "name": "text",
                                     "type": "text",
                                   },
                                   {
-                                    "localized": true,
                                     "name": "href",
                                     "type": "text",
                                   },
@@ -4549,12 +4533,10 @@ describe('payload-crowdin-sync: getLocalizedFields', () => {
                               {
                                 "fields": [
                                   {
-                                    "localized": true,
                                     "name": "title",
                                     "type": "text",
                                   },
                                   {
-                                    "localized": true,
                                     "name": "content",
                                     "type": "richText",
                                   },

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -71,6 +71,7 @@ export default buildConfig({
 | `pluginCollectionAccess` | `undefined` | `access` collection config to pass to all the Crowdin collections created by this plugin. |
 | `pluginCollectionAdmin` | `undefined`<br />`{ hidden: ({ user }) => !userIsAdmin({ user }) }` | `admin` collection config to pass to all the Crowdin collections created by this plugin. |
 | `tabbedUI` | `undefined`<br />`true` | Appends `Crowdin` tab onto your config using Payload's [Tabs Field](https://payloadcms.com/docs/fields/tabs). If your collection is not already tab-enabled, meaning the first field in your config is not of type `tabs`, then one will be created for you called `Content`. |
+| `richTextBlockFieldNameSeparator` | `$$$` | Default `--`. Used as a separator when constructing file names for Lexical block fields in Crowdin. |
 
 ### Environment variables
 

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -255,7 +255,6 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
           ],
           isLocalized: reLocalizeField, // ignore localized attribute
         });
-        // console.log('currentCrowdinJsonData', currentCrowdinJsonData, 'currentCrowdinHtmlData', currentCrowdinHtmlData)
         await this.createOrUpdateJsonFile(currentCrowdinJsonData, fieldName);
         await Promise.all(Object.keys(currentCrowdinHtmlData).map(async (name) => {
           await this.createOrUpdateHtmlFile({

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -12,7 +12,7 @@ import {
 } from "../../helpers";
 import { Descendant } from "slate";
 import { convertLexicalToHtml, convertSlateToHtml, findField } from '../../../utilities';
-import { getLexicalEditorConfig } from '../../../utilities/lexical';
+import { extractLexicalBlockContent, getLexicalEditorConfig } from '../../../utilities/lexical';
 
 type FileData = string | object;
 
@@ -225,6 +225,8 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
 
       if (editorConfig) {
         html = await convertLexicalToHtml(value, editorConfig)
+        const blockContent = value && extractLexicalBlockContent(value.root)
+        console.log('blockContent', blockContent)
       } else {
         html = "<span>lexical configuration not found</span>"
       }

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -11,8 +11,8 @@ import {
   getFiles
 } from "../../helpers";
 import { Descendant } from "slate";
-import { convertLexicalToHtml, convertSlateToHtml, findField } from '../../../utilities';
-import { extractLexicalBlockContent, getLexicalEditorConfig } from '../../../utilities/lexical';
+import { buildCrowdinHtmlObject, buildCrowdinJsonObject, convertLexicalToHtml, convertSlateToHtml, findField, reLocalizeField } from '../../../utilities';
+import { extractLexicalBlockContent, getLexicalBlockFields, getLexicalEditorConfig } from '../../../utilities/lexical';
 
 type FileData = string | object;
 
@@ -197,9 +197,9 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
     return payloadFile;
   }
 
-  async createOrUpdateJsonFile(fileData: FileData) {
+  async createOrUpdateJsonFile(fileData: FileData, fileName = "fields") {
     await this.createOrUpdateFile({
-      name: "fields",
+      name: fileName,
       fileData,
       fileType: "json",
     });
@@ -225,8 +225,45 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
 
       if (editorConfig) {
         html = await convertLexicalToHtml(value, editorConfig)
+        // no need to detect change - this has already been done on the field's JSON object
         const blockContent = value && extractLexicalBlockContent(value.root)
-        console.log('blockContent', blockContent)
+        const blockConfig = getLexicalBlockFields(editorConfig)
+        const fieldName = `${name}--blocks`
+        const currentCrowdinJsonData = buildCrowdinJsonObject({
+          doc: {
+            [fieldName]: blockContent,
+          },
+          fields: [
+            {
+              name: fieldName,
+              type: 'blocks',
+              blocks: blockConfig.blocks,
+            }
+          ],
+          isLocalized: reLocalizeField, // ignore localized attribute
+        });
+        const currentCrowdinHtmlData = buildCrowdinHtmlObject({
+          doc: {
+            [fieldName]: blockContent,
+          },
+          fields: [
+            {
+              name: fieldName,
+              type: 'blocks',
+              blocks: blockConfig.blocks,
+            }
+          ],
+          isLocalized: reLocalizeField, // ignore localized attribute
+        });
+        console.log('currentCrowdinJsonData', currentCrowdinJsonData, 'currentCrowdinHtmlData', currentCrowdinHtmlData)
+        await this.createOrUpdateJsonFile(currentCrowdinJsonData, fieldName);
+        await Promise.all(Object.keys(currentCrowdinHtmlData).map(async (name) => {
+          await this.createOrUpdateHtmlFile({
+            name,
+            value: currentCrowdinHtmlData[name] as Descendant[],
+            collection,
+          });
+        }));
       } else {
         html = "<span>lexical configuration not found</span>"
       }

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -228,7 +228,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
         // no need to detect change - this has already been done on the field's JSON object
         const blockContent = value && extractLexicalBlockContent(value.root)
         const blockConfig = getLexicalBlockFields(editorConfig)
-        const fieldName = `${name}--blocks`
+        const fieldName = `${name}${this.pluginOptions.richTextBlockFieldNameSeparator}blocks`
         const currentCrowdinJsonData = buildCrowdinJsonObject({
           doc: {
             [fieldName]: blockContent,

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -255,7 +255,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
           ],
           isLocalized: reLocalizeField, // ignore localized attribute
         });
-        console.log('currentCrowdinJsonData', currentCrowdinJsonData, 'currentCrowdinHtmlData', currentCrowdinHtmlData)
+        // console.log('currentCrowdinJsonData', currentCrowdinJsonData, 'currentCrowdinHtmlData', currentCrowdinHtmlData)
         await this.createOrUpdateJsonFile(currentCrowdinJsonData, fieldName);
         await Promise.all(Object.keys(currentCrowdinHtmlData).map(async (name) => {
           await this.createOrUpdateHtmlFile({

--- a/plugin/src/lib/api/payload-crowdin-sync/translations.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/translations.ts
@@ -21,8 +21,8 @@ import {
   convertHtmlToSlate,
 } from "../../utilities";
 
-import { Config, CrowdinArticleDirectory, CrowdinFile } from "../../payload-types";
-import { getArticleDirectory, getFileByDocumentID, getFilesByDocumentID } from "../helpers";
+import { Config } from "../../payload-types";
+import { getFileByDocumentID, getFilesByDocumentID } from "../helpers";
 
 interface IgetLatestDocumentTranslation {
   collection: string;

--- a/plugin/src/lib/plugin.ts
+++ b/plugin/src/lib/plugin.ts
@@ -99,6 +99,7 @@ export const crowdinSync =
       pluginCollectionAccess: Joi.object(),
       pluginCollectionAdmin: Joi.object(),
       tabbedUI: Joi.boolean(),
+      richTextBlockFieldNameSeparator: Joi.string(),
     });
 
     const validate = schema.validate(pluginOptions);
@@ -109,6 +110,9 @@ export const crowdinSync =
         validate.error
       );
     }
+
+    // option defaults
+    pluginOptions.richTextBlockFieldNameSeparator = pluginOptions.richTextBlockFieldNameSeparator || '--';
 
     return {
       ...config,

--- a/plugin/src/lib/types.ts
+++ b/plugin/src/lib/types.ts
@@ -43,6 +43,7 @@ export interface PluginOptions {
   pluginCollectionAccess?: CollectionConfig["access"];
   pluginCollectionAdmin?: CollectionConfig["admin"];
   tabbedUI?: boolean
+  richTextBlockFieldNameSeparator?: string
 }
 
 export type FieldWithName = Field & { name: string };

--- a/plugin/src/lib/utilities/lexical/index.ts
+++ b/plugin/src/lib/utilities/lexical/index.ts
@@ -1,5 +1,5 @@
 import { LexicalRichTextAdapter, SanitizedEditorConfig } from "@payloadcms/richtext-lexical";
-import { RichTextField } from "payload/types";
+import { Block, RichTextField } from "payload/types";
 import { SerializedRootNode, SerializedLexicalNode } from "lexical"
 import { SerializedBlockNode } from "@payloadcms/richtext-lexical";
 
@@ -18,7 +18,9 @@ export const getLexicalEditorConfig = (field: RichTextField) => {
   return undefined
 }
 
-export const getLexicalBlockFields = (editorConfig: SanitizedEditorConfig) => editorConfig.resolvedFeatureMap.get('blocks')?.props
+export const getLexicalBlockFields = (editorConfig: SanitizedEditorConfig) => editorConfig.resolvedFeatureMap.get('blocks')?.props as {
+  blocks: Block[]
+}
 
 export const extractLexicalBlockContent = (root: SerializedRootNode) => {
   const nodes = root.children


### PR DESCRIPTION
Ideally, Lexical blocks contain non-localized fields. This makes sense and in fact, some fields don't work if localized. As a result, we need a way to 're-localize' to include fields in the plugin localization logic.