### PR TITLE
fix(payloadconfig): replace happy-dom with existing global

### DIFF
--- a/dev/src/lib/payload.config.ts
+++ b/dev/src/lib/payload.config.ts
@@ -56,7 +56,7 @@ export default buildConfig({
           }
         },
         externals: {
-          'happy-dom': 'happy-dom',
+          'happy-dom': 'window',
         }
       }
     },


### PR DESCRIPTION
It isn't possible to run Payload locally without this patch - although `happy-dom` is not used in Webpack compiled Payload, we need to suggest it is replaced with a global that exists.