### PR TITLE
feat(crowdinarticledirectories): add parent field

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [17.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/dev-alternative-config/src/lib/payload-types.ts
+++ b/dev-alternative-config/src/lib/payload-types.ts
@@ -29,10 +29,18 @@ export interface Config {
     statistics: Statistic;
   };
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories".
+ */
 export interface Category {
   id: string;
   name?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "multi-rich-text".
+ */
 export interface MultiRichText {
   id: string;
   field_0?:
@@ -96,12 +104,17 @@ export interface MultiRichText {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-article-directories".
+ */
 export interface CrowdinArticleDirectory {
   id: string;
   excludeLocales?: ('de_DE' | 'fr_FR')[] | null;
   name?: string | null;
   crowdinCollectionDirectory?: (string | null) | CrowdinCollectionDirectory;
   crowdinFiles?: (string | CrowdinFile)[] | null;
+  parent?: (string | null) | CrowdinArticleDirectory;
   reference?: {
     createdAt?: string | null;
     updatedAt?: string | null;
@@ -112,6 +125,10 @@ export interface CrowdinArticleDirectory {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-collection-directories".
+ */
 export interface CrowdinCollectionDirectory {
   id: string;
   name?: string | null;
@@ -127,6 +144,10 @@ export interface CrowdinCollectionDirectory {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-files".
+ */
 export interface CrowdinFile {
   id: string;
   title?: string | null;
@@ -141,7 +162,7 @@ export interface CrowdinFile {
   directoryId?: number | null;
   revisionId?: number | null;
   name?: string | null;
-  type?: string | null;
+  type?: ('json' | 'html') | null;
   path?: string | null;
   fileData?: {
     json?:
@@ -158,6 +179,10 @@ export interface CrowdinFile {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-posts".
+ */
 export interface LocalizedPost {
   id: string;
   title?: string | null;
@@ -178,6 +203,10 @@ export interface LocalizedPost {
   createdAt: string;
   _status?: ('draft' | 'published') | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users".
+ */
 export interface User {
   id: string;
   name?: string | null;
@@ -192,10 +221,18 @@ export interface User {
   lockUntil?: string | null;
   password: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags".
+ */
 export interface Tag {
   id: string;
   name?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-field-collection".
+ */
 export interface NestedFieldCollection {
   id: string;
   title?: string | null;
@@ -308,17 +345,19 @@ export interface NestedFieldCollection {
         }[]
       | null;
   };
-  syncTranslations?: boolean | null;
-  syncAllTranslations?: boolean | null;
-  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "policies".
+ */
 export interface Policy {
   id: string;
   title?: string | null;
   content?: {
     root: {
+      type: string;
       children: {
         type: string;
         version: number;
@@ -327,17 +366,17 @@ export interface Policy {
       direction: ('ltr' | 'rtl') | null;
       format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
       indent: number;
-      type: string;
       version: number;
     };
     [k: string]: unknown;
   } | null;
-  syncTranslations?: boolean | null;
-  syncAllTranslations?: boolean | null;
-  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts".
+ */
 export interface Post {
   id: string;
   title?: string | null;
@@ -354,6 +393,10 @@ export interface Post {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-posts-with-condition".
+ */
 export interface LocalizedPostsWithCondition {
   id: string;
   title?: string | null;
@@ -375,6 +418,10 @@ export interface LocalizedPostsWithCondition {
   createdAt: string;
   _status?: ('draft' | 'published') | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-preferences".
+ */
 export interface PayloadPreference {
   id: string;
   user: {
@@ -394,6 +441,10 @@ export interface PayloadPreference {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-migrations".
+ */
 export interface PayloadMigration {
   id: string;
   name?: string | null;
@@ -401,18 +452,23 @@ export interface PayloadMigration {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-nav".
+ */
 export interface LocalizedNav {
   id: string;
   items: {
     label?: string | null;
     id?: string | null;
   }[];
-  syncTranslations?: boolean | null;
-  syncAllTranslations?: boolean | null;
-  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
   updatedAt?: string | null;
   createdAt?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nav".
+ */
 export interface Nav {
   id: string;
   items: {
@@ -422,6 +478,10 @@ export interface Nav {
   updatedAt?: string | null;
   createdAt?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "statistics".
+ */
 export interface Statistic {
   id: string;
   users?: {

--- a/dev/project.json
+++ b/dev/project.json
@@ -22,7 +22,9 @@
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "dev/jest.config.ts"
+        "jestConfig": "dev/jest.config.ts",
+        "forceExit": true,
+        "detectOpenHandles": true,
       }
     }
   },

--- a/dev/src/lib/payload-types.ts
+++ b/dev/src/lib/payload-types.ts
@@ -11,6 +11,7 @@ export interface Config {
     categories: Category;
     'multi-rich-text': MultiRichText;
     'localized-posts': LocalizedPost;
+    media: Media;
     'nested-field-collection': NestedFieldCollection;
     policies: Policy;
     posts: Post;
@@ -29,10 +30,18 @@ export interface Config {
     statistics: Statistic;
   };
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories".
+ */
 export interface Category {
   id: string;
   name?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "multi-rich-text".
+ */
 export interface MultiRichText {
   id: string;
   field_0?:
@@ -96,12 +105,17 @@ export interface MultiRichText {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-article-directories".
+ */
 export interface CrowdinArticleDirectory {
   id: string;
   excludeLocales?: ('de_DE' | 'fr_FR')[] | null;
   name?: string | null;
   crowdinCollectionDirectory?: (string | null) | CrowdinCollectionDirectory;
   crowdinFiles?: (string | CrowdinFile)[] | null;
+  parent?: (string | null) | CrowdinArticleDirectory;
   reference?: {
     createdAt?: string | null;
     updatedAt?: string | null;
@@ -112,6 +126,10 @@ export interface CrowdinArticleDirectory {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-collection-directories".
+ */
 export interface CrowdinCollectionDirectory {
   id: string;
   name?: string | null;
@@ -127,6 +145,10 @@ export interface CrowdinCollectionDirectory {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-files".
+ */
 export interface CrowdinFile {
   id: string;
   title?: string | null;
@@ -141,7 +163,7 @@ export interface CrowdinFile {
   directoryId?: number | null;
   revisionId?: number | null;
   name?: string | null;
-  type?: string | null;
+  type?: ('json' | 'html') | null;
   path?: string | null;
   fileData?: {
     json?:
@@ -158,6 +180,10 @@ export interface CrowdinFile {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-posts".
+ */
 export interface LocalizedPost {
   id: string;
   title?: string | null;
@@ -178,6 +204,10 @@ export interface LocalizedPost {
   createdAt: string;
   _status?: ('draft' | 'published') | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users".
+ */
 export interface User {
   id: string;
   name?: string | null;
@@ -192,10 +222,62 @@ export interface User {
   lockUntil?: string | null;
   password: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags".
+ */
 export interface Tag {
   id: string;
   name?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media".
+ */
+export interface Media {
+  id: string;
+  alt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+  sizes?: {
+    thumbnail?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    card?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    tablet?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+  };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-field-collection".
+ */
 export interface NestedFieldCollection {
   id: string;
   title?: string | null;
@@ -314,11 +396,16 @@ export interface NestedFieldCollection {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "policies".
+ */
 export interface Policy {
   id: string;
   title?: string | null;
   content?: {
     root: {
+      type: string;
       children: {
         type: string;
         version: number;
@@ -327,7 +414,6 @@ export interface Policy {
       direction: ('ltr' | 'rtl') | null;
       format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
       indent: number;
-      type: string;
       version: number;
     };
     [k: string]: unknown;
@@ -338,6 +424,7 @@ export interface Policy {
           title?: string | null;
           content?: {
             root: {
+              type: string;
               children: {
                 type: string;
                 version: number;
@@ -346,7 +433,6 @@ export interface Policy {
               direction: ('ltr' | 'rtl') | null;
               format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
               indent: number;
-              type: string;
               version: number;
             };
             [k: string]: unknown;
@@ -361,6 +447,10 @@ export interface Policy {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts".
+ */
 export interface Post {
   id: string;
   title?: string | null;
@@ -377,6 +467,10 @@ export interface Post {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-posts-with-condition".
+ */
 export interface LocalizedPostsWithCondition {
   id: string;
   title?: string | null;
@@ -398,6 +492,10 @@ export interface LocalizedPostsWithCondition {
   createdAt: string;
   _status?: ('draft' | 'published') | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-preferences".
+ */
 export interface PayloadPreference {
   id: string;
   user: {
@@ -417,6 +515,10 @@ export interface PayloadPreference {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-migrations".
+ */
 export interface PayloadMigration {
   id: string;
   name?: string | null;
@@ -424,6 +526,10 @@ export interface PayloadMigration {
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-nav".
+ */
 export interface LocalizedNav {
   id: string;
   items: {
@@ -436,6 +542,10 @@ export interface LocalizedNav {
   updatedAt?: string | null;
   createdAt?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nav".
+ */
 export interface Nav {
   id: string;
   items: {
@@ -445,6 +555,10 @@ export interface Nav {
   updatedAt?: string | null;
   createdAt?: string | null;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "statistics".
+ */
 export interface Statistic {
   id: string;
   users?: {

--- a/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
@@ -6,7 +6,7 @@ import { fixture } from './lexical-editor-with-blocks.fixture';
 import nock from 'nock';
 import { mockCrowdinClient } from 'plugin/src/lib/api/mock/crowdin-api-responses';
 import { pluginConfig } from '../helpers/plugin-config';
-import { Policy } from '../../payload-types';
+import { CrowdinArticleDirectory, Policy } from '../../payload-types';
 
 const pluginOptions = pluginConfig();
 const mockClient = mockCrowdinClient(pluginOptions);
@@ -37,7 +37,7 @@ describe('Lexical editor with blocks', () => {
   it('builds a Crowdin HTML object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .twice()
+      .times(4)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -301,6 +301,7 @@ describe('Lexical editor with blocks', () => {
   it('builds a Crowdin JSON object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .times(3)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -331,6 +332,7 @@ describe('Lexical editor with blocks', () => {
   it('builds a Payload update object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .thrice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -605,6 +607,7 @@ describe('Lexical editor with blocks', () => {
   it('creates an HTML file for Crowdin as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .thrice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -640,6 +643,7 @@ describe('Lexical editor with blocks', () => {
   it('creates HTML files for Crowdin as expected for lexical content within an array field that is embedded in a group', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .times(5)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(7)
@@ -672,7 +676,7 @@ describe('Lexical editor with blocks', () => {
     const ids = arrayField.map((item) => item.id) || ([] as string[]);
 
     const crowdinFiles = await getFilesByDocumentID(`${policy.id}`, payload);
-    expect(crowdinFiles.length).toEqual(7);
+    expect(crowdinFiles.length).toEqual(3);
 
     const htmlFileOne = crowdinFiles.find(
       (file) => file.name === `group.array.${ids[0]}.content.html`
@@ -686,6 +690,11 @@ describe('Lexical editor with blocks', () => {
     expect(
       crowdinFiles.find((file) => file.name === 'fields.json')
     ).toBeDefined();
+    
+    const fileOneCrowdinFiles = await getFilesByDocumentID(`group.array.${ids[0]}.content`, payload, policy.crowdinArticleDirectory as CrowdinArticleDirectory);
+    const fileTwoCrowdinFiles = await getFilesByDocumentID(`group.array.${ids[1]}.content`, payload, policy.crowdinArticleDirectory as CrowdinArticleDirectory);
+    expect(fileOneCrowdinFiles.length).toEqual(2);
+    expect(fileTwoCrowdinFiles.length).toEqual(2);
 
     expect(htmlFileOne?.fileData?.html).toMatchInlineSnapshot(
       `"<h2>Lexical editor content</h2><p>This is editable <strong>rich</strong> text, <em>much</em> better than a <code><textarea></code>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p>Try it out for yourself!</p><p></p><span data-block-id=6582d48f2037fb3ca72ed2cf></span><p></p>"`

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,24 @@
+# nock
+
+Testing with `nock` can become quite complex.
+
+For failing tests involving nock, consider outputting all the Crowdin API calls by:
+
+- `console.log` the fetch call in 
+- add `console.log` calls as necessary in `node_modules/@crowdin/crowdin-api-client`. 
+
+```
+// updates a Payload article with a rich text field that uses the Lexical editor with multiple blocks with a translation received from Crowdin
+
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/files/56641
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/56641/download?targetLanguageId=de
+
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/files/56644
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/56644/download?targetLanguageId=de
+
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/files/56641
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/56641/download?targetLanguageId=fr
+
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/files/56644
+https://api.crowdin.com/api/v2/projects/323731/translations/builds/56644/download?targetLanguageId=fr
+```

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -1,0 +1,16 @@
+# Engineering decisions
+
+## Lexical block fields
+
+The `createOrUpdateHtmlFile` method of the [`payloadCrowdinSyncDocumentFilesApi`](plugin/src/lib/api/payload-crowdin-sync/files/document.ts) reads the collection config to determine whether the underlying field uses the [Slate editor](https://payloadcms.com/docs/rich-text/slate) or the [Lexical editor](https://payloadcms.com/docs/rich-text/lexical).
+
+If Lexical, blocks embedded within the editor are supported.
+
+For a given Lexical field, all embedded blocks are extracted and another instance of `payloadCrowdinSyncDocumentFilesApi` is used to process these blocks as if they were the fields in a document.
+
+Rationale:
+
+- Reuse logic (e.g. preparing JSON/HTML for Crowdin)
+- Organise Lexical block fields into a folder (easier to review)
+- Remove the need for richTextBlockFieldNameSeparator. the use of this led to field names that don't exist.
+- Logical - fields in blocks are easier to treat as a new 'document' rather than continuing to name them with increasing long field names to describe where they are nested.

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "jest": "^29.7.0",
         "jest-environment-node": "^29.7.0",
         "mongodb-memory-server": "^9.1.6",
-        "nock": "^13.5.4",
+        "nock": "14.0.0-beta.9",
         "nodemon": "^3.1.4",
         "nx": "19.5.2",
         "prettier": "^3.3.3",
@@ -5657,6 +5657,23 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.33.2.tgz",
+      "integrity": "sha512-uDB/51Sraq4lxT73Z1LXL75lE7rO4313zJEcvMFusMouqy/RrAXkToMhurbfl9CUHYMn77icAqCzhQYDBD34PQ==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -6568,6 +6585,28 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@payloadcms/bundler-webpack": {
       "version": "1.0.7",
@@ -15141,6 +15180,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -18764,17 +18809,17 @@
       }
     },
     "node_modules/nock": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "version": "14.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.9.tgz",
+      "integrity": "sha512-ndEFjtOLDluzu/1srE2raRWlEyQHq4CWZ/eN6fc7AcbaXiXmprIkfvq3MvkFYR3rQW7Pylb+IHLkx7RITMUwTg==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.33.2",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">= 18"
       }
     },
     "node_modules/node-abi": {
@@ -19599,6 +19644,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -23773,6 +23824,12 @@
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -29695,6 +29752,20 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "@mswjs/interceptors": {
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.33.2.tgz",
+      "integrity": "sha512-uDB/51Sraq4lxT73Z1LXL75lE7rO4313zJEcvMFusMouqy/RrAXkToMhurbfl9CUHYMn77icAqCzhQYDBD34PQ==",
+      "dev": true,
+      "requires": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      }
+    },
     "@napi-rs/wasm-runtime": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -30326,6 +30397,28 @@
           }
         }
       }
+    },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "@payloadcms/bundler-webpack": {
       "version": "1.0.7",
@@ -36683,6 +36776,12 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
     },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -39391,12 +39490,12 @@
       }
     },
     "nock": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "version": "14.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.9.tgz",
+      "integrity": "sha512-ndEFjtOLDluzu/1srE2raRWlEyQHq4CWZ/eN6fc7AcbaXiXmprIkfvq3MvkFYR3rQW7Pylb+IHLkx7RITMUwTg==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.33.2",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       }
@@ -39996,6 +40095,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
+    },
+    "outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true
     },
     "p-limit": {
@@ -42844,6 +42949,12 @@
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
       }
+    },
+    "strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "0.10.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "jest": "^29.7.0",
         "jest-environment-node": "^29.7.0",
         "mongodb-memory-server": "^9.1.6",
-        "nock": "14.0.0-beta.9",
+        "nock": "13.5.4",
         "nodemon": "^3.1.4",
         "nx": "19.5.2",
         "prettier": "^3.3.3",
@@ -5657,23 +5657,6 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
-    "node_modules/@mswjs/interceptors": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.33.2.tgz",
-      "integrity": "sha512-uDB/51Sraq4lxT73Z1LXL75lE7rO4313zJEcvMFusMouqy/RrAXkToMhurbfl9CUHYMn77icAqCzhQYDBD34PQ==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -6585,28 +6568,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true
-    },
-    "node_modules/@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "dependencies": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
-    "node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
     },
     "node_modules/@payloadcms/bundler-webpack": {
       "version": "1.0.7",
@@ -11829,6 +11790,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/dataloader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
@@ -13265,6 +13235,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -13557,6 +13550,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -15180,12 +15185,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -15436,6 +15435,44 @@
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/isomorphic-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/isomorphic-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/isomorphic-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/isomorphic.js": {
@@ -18809,17 +18846,17 @@
       }
     },
     "node_modules/nock": {
-      "version": "14.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.9.tgz",
-      "integrity": "sha512-ndEFjtOLDluzu/1srE2raRWlEyQHq4CWZ/eN6fc7AcbaXiXmprIkfvq3MvkFYR3rQW7Pylb+IHLkx7RITMUwTg==",
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
       "dev": true,
       "dependencies": {
-        "@mswjs/interceptors": "^0.33.2",
+        "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-abi": {
@@ -18868,42 +18905,41 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
         }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -19644,12 +19680,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/outvariant": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -23825,12 +23855,6 @@
         "queue-tick": "^1.0.1"
       }
     },
-    "node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -25240,6 +25264,15 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -29752,20 +29785,6 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
-    "@mswjs/interceptors": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.33.2.tgz",
-      "integrity": "sha512-uDB/51Sraq4lxT73Z1LXL75lE7rO4313zJEcvMFusMouqy/RrAXkToMhurbfl9CUHYMn77icAqCzhQYDBD34PQ==",
-      "dev": true,
-      "requires": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      }
-    },
     "@napi-rs/wasm-runtime": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -30397,28 +30416,6 @@
           }
         }
       }
-    },
-    "@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true
-    },
-    "@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "requires": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
-    "@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
     },
     "@payloadcms/bundler-webpack": {
       "version": "1.0.7",
@@ -34341,6 +34338,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true
+    },
     "dataloader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
@@ -35405,6 +35408,16 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -35622,6 +35635,15 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "forwarded": {
@@ -36776,12 +36798,6 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
     },
-    "is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -36951,6 +36967,35 @@
       "requires": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "isomorphic.js": {
@@ -39490,12 +39535,12 @@
       }
     },
     "nock": {
-      "version": "14.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.9.tgz",
-      "integrity": "sha512-ndEFjtOLDluzu/1srE2raRWlEyQHq4CWZ/eN6fc7AcbaXiXmprIkfvq3MvkFYR3rQW7Pylb+IHLkx7RITMUwTg==",
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
       "dev": true,
       "requires": {
-        "@mswjs/interceptors": "^0.33.2",
+        "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       }
@@ -39536,33 +39581,21 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true
+    },
     "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-int64": {
@@ -40095,12 +40128,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true
-    },
-    "outvariant": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true
     },
     "p-limit": {
@@ -42950,12 +42977,6 @@
         "queue-tick": "^1.0.1"
       }
     },
-    "strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -43960,6 +43981,12 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
     "mongodb-memory-server": "^9.1.6",
-    "nock": "^13.5.4",
+    "nock": "14.0.0-beta.9",
     "nodemon": "^3.1.4",
     "nx": "19.5.2",
     "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
     "mongodb-memory-server": "^9.1.6",
-    "nock": "14.0.0-beta.9",
+    "nock": "13.5.4",
     "nodemon": "^3.1.4",
     "nx": "19.5.2",
     "prettier": "^3.3.3",
@@ -77,6 +77,6 @@
     "includedScripts": []
   },
   "volta": {
-    "node": "18.20.4"
+    "node": "17.9.1"
   }
 }

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -1,9 +1,7 @@
-import payload, { Payload } from "payload";
+import { Payload } from "payload";
 import { CrowdinArticleDirectory, CrowdinCollectionDirectory, CrowdinFile } from "../payload-types";
 import { payloadCrowdinSyncTranslationsApi } from "./payload-crowdin-sync/translations";
 import { PluginOptions, isCollectionOrGlobalConfigObject, isCollectionOrGlobalConfigSlug } from "../types";
-import { ReadableStreamDefaultController } from "stream/web";
-import { Plugin } from "payload/config";
 
 /**
  * get Crowdin Article Directory for a given documentId
@@ -15,7 +13,8 @@ import { Plugin } from "payload/config";
 export async function getArticleDirectory(
   documentId: string,
   payload: Payload,
-  allowEmpty?: boolean
+  allowEmpty?: boolean,
+  parent?: CrowdinArticleDirectory,
 ) {
   // Get directory
   const crowdinPayloadArticleDirectory = await payload.find({
@@ -24,6 +23,11 @@ export async function getArticleDirectory(
       name: {
         equals: documentId,
       },
+      ...(parent && {
+        parent: {
+          equals: parent?.id,
+        }
+      })
     },
   });
   if (crowdinPayloadArticleDirectory.totalDocs === 0 && allowEmpty) {
@@ -82,9 +86,10 @@ export async function getFileByDocumentID(
 
 export async function getFilesByDocumentID(
   documentId: string,
-  payload: Payload
+  payload: Payload,
+  parent?: CrowdinArticleDirectory,
 ): Promise<CrowdinFile[]> {
-  const articleDirectory = await getArticleDirectory(documentId, payload);
+  const articleDirectory = await getArticleDirectory(documentId, payload, false, parent);
   if (!articleDirectory) {
     // tests call this function to make sure files are deleted
     return [];

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -231,17 +231,6 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
         // no need to detect change - this has already been done on the field's JSON object
         const blockContent = value && extractLexicalBlockContent(value.root)
         const blockConfig = getLexicalBlockFields(editorConfig)
-
-        /**
-         * Manage block fields
-         * Use another instance of this class that sets name as the lexical field name. Compare this to a document that uses it's id.
-         * 
-         * Advantages:
-         * * Reuse logic (e.g. preparing JSON/HTML for Crowdin)
-         * * Organise Lexical block fields into a folder (easier to review)
-         * * Remove the need for richTextBlockFieldNameSeparator. the use of this led to field names that don't exist.
-         * * Logical - fields in blocks are easier to treat as a new 'document' rather than continuing to name them with increasing long field names to describe where they are nested.
-         */
         
         /**
          * Initialize Crowdin client sourceFilesApi

--- a/plugin/src/lib/collections/CrowdinArticleDirectories.ts
+++ b/plugin/src/lib/collections/CrowdinArticleDirectories.ts
@@ -43,6 +43,14 @@ const CrowdinArticleDirectories: CollectionConfig = {
         readOnly: true,
       }
     },
+    {
+      name: "parent",
+      type: "relationship",
+      relationTo: "crowdin-article-directories",
+      admin: {
+        readOnly: true,
+      }
+    },
     /* Crowdin fields */
     {
       type: "group",

--- a/plugin/src/lib/payload-types.ts
+++ b/plugin/src/lib/payload-types.ts
@@ -9,93 +9,162 @@
 export interface Config {
   collections: {
     categories: Category;
-    "localized-posts": LocalizedPost;
-    "nested-field-collection": NestedFieldCollection;
+    'multi-rich-text': MultiRichText;
+    'localized-posts': LocalizedPost;
+    media: Media;
+    'nested-field-collection': NestedFieldCollection;
+    policies: Policy;
     posts: Post;
+    'localized-posts-with-condition': LocalizedPostsWithCondition;
     tags: Tag;
     users: User;
-    "crowdin-files": CrowdinFile;
-    "crowdin-collection-directories": CrowdinCollectionDirectory;
-    "crowdin-article-directories": CrowdinArticleDirectory;
+    'crowdin-files': CrowdinFile;
+    'crowdin-collection-directories': CrowdinCollectionDirectory;
+    'crowdin-article-directories': CrowdinArticleDirectory;
+    'payload-preferences': PayloadPreference;
+    'payload-migrations': PayloadMigration;
   };
   globals: {
+    'localized-nav': LocalizedNav;
     nav: Nav;
+    statistics: Statistic;
   };
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories".
+ */
 export interface Category {
   id: string;
-  name?: string;
+  name?: string | null;
 }
-export interface LocalizedPost {
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "multi-rich-text".
+ */
+export interface MultiRichText {
   id: string;
-  title?: string;
-  author?: string | User;
-  publishedDate?: string;
-  category?: string | Category;
-  tags?: string[] | Tag[];
-  content?: {
-    [k: string]: unknown;
-  }[];
-  status?: "draft" | "published";
-  crowdinArticleDirectory?: string | CrowdinArticleDirectory;
+  field_0?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_1?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_2?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_3?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_4?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_5?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_6?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_7?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_8?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_9?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  field_10?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  syncTranslations?: boolean | null;
+  syncAllTranslations?: boolean | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
   updatedAt: string;
   createdAt: string;
 }
-export interface User {
-  id: string;
-  name?: string;
-  updatedAt: string;
-  createdAt: string;
-  email: string;
-  resetPasswordToken?: string;
-  resetPasswordExpiration?: string;
-  salt?: string;
-  hash?: string;
-  loginAttempts?: number;
-  lockUntil?: string;
-  password?: string;
-}
-export interface Tag {
-  id: string;
-  name?: string;
-}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-article-directories".
+ */
 export interface CrowdinArticleDirectory {
   id: string;
-  name?: string;
-  crowdinCollectionDirectory?: string | CrowdinCollectionDirectory;
-  crowdinFiles?: string[] | CrowdinFile[];
-  createdAt: string;
+  excludeLocales?: ('de_DE' | 'fr_FR')[] | null;
+  name?: string | null;
+  crowdinCollectionDirectory?: (string | null) | CrowdinCollectionDirectory;
+  crowdinFiles?: (string | CrowdinFile)[] | null;
+  parent?: (string | null) | CrowdinArticleDirectory;
+  reference?: {
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    projectId?: number | null;
+  };
+  originalId?: number | null;
+  directoryId?: number | null;
   updatedAt: string;
-  originalId?: number;
-  projectId?: number;
-  directoryId?: number;
-  excludeLocales?: ("de_DE" | "fr_FR")[];
+  createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-collection-directories".
+ */
 export interface CrowdinCollectionDirectory {
   id: string;
-  name?: string;
-  title?: string;
-  collectionSlug?: string;
-  createdAt: string;
+  name?: string | null;
+  title?: string | null;
+  collectionSlug?: string | null;
+  reference?: {
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    projectId?: number | null;
+  };
+  originalId?: number | null;
+  directoryId?: number | null;
   updatedAt: string;
-  originalId?: number;
-  projectId?: number;
-  directoryId?: number;
+  createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "crowdin-files".
+ */
 export interface CrowdinFile {
   id: string;
-  title?: string;
-  field?: string;
-  crowdinArticleDirectory?: string | CrowdinArticleDirectory;
-  createdAt: string;
-  updatedAt: string;
-  originalId?: number;
-  projectId?: number;
-  directoryId?: number;
-  revisionId?: number;
-  name?: string;
-  type?: string;
-  path?: string;
+  title?: string | null;
+  field?: string | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
+  reference?: {
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    projectId?: number | null;
+  };
+  originalId?: number | null;
+  directoryId?: number | null;
+  revisionId?: number | null;
+  name?: string | null;
+  type?: ('json' | 'html') | null;
+  path?: string | null;
   fileData?: {
     json?:
       | {
@@ -106,109 +175,404 @@ export interface CrowdinFile {
       | number
       | boolean
       | null;
-    html?: string;
+    html?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-posts".
+ */
+export interface LocalizedPost {
+  id: string;
+  title?: string | null;
+  author?: (string | null) | User;
+  publishedDate?: string | null;
+  category?: (string | null) | Category;
+  tags?: (string | Tag)[] | null;
+  content?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  status?: ('draft' | 'published') | null;
+  syncTranslations?: boolean | null;
+  syncAllTranslations?: boolean | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users".
+ */
+export interface User {
+  id: string;
+  name?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  password: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags".
+ */
+export interface Tag {
+  id: string;
+  name?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media".
+ */
+export interface Media {
+  id: string;
+  alt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+  sizes?: {
+    thumbnail?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    card?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+    tablet?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
   };
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-field-collection".
+ */
 export interface NestedFieldCollection {
   id: string;
-  textField?: string;
-  richTextField?: {
-    [k: string]: unknown;
-  }[];
-  textareaField?: string;
-  arrayField?: {
-    textField?: string;
-    richTextField?: {
-      [k: string]: unknown;
-    }[];
-    textareaField?: string;
-    id?: string;
-  }[];
-  layout?: (
+  title?: string | null;
+  textField?: string | null;
+  richTextField?:
     | {
-        textField?: string;
-        richTextField?: {
-          [k: string]: unknown;
-        }[];
-        textareaField?: string;
-        id?: string;
-        blockName?: string;
-        blockType: "basicBlock";
-      }
+        [k: string]: unknown;
+      }[]
+    | null;
+  textareaField?: string | null;
+  arrayField?:
     | {
-        richTextField?: {
-          [k: string]: unknown;
-        }[];
-        id?: string;
-        blockName?: string;
-        blockType: "basicBlockRichText";
-      }
-    | {
-        textField?: string;
-        richTextField?: {
-          [k: string]: unknown;
-        }[];
-        textareaField?: string;
-        id?: string;
-        blockName?: string;
-        blockType: "basicBlockMixed";
-      }
-    | {
-        title?: string;
-        messages?: {
-          title?: string;
-          message?: {
-            [k: string]: unknown;
-          }[];
-          id?: string;
-        }[];
-        id?: string;
-        blockName?: string;
-        blockType: "testBlockArrayOfRichText";
-      }
-  )[];
+        textField?: string | null;
+        richTextField?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        textareaField?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  layout?:
+    | (
+        | {
+            textField?: string | null;
+            richTextField?:
+              | {
+                  [k: string]: unknown;
+                }[]
+              | null;
+            textareaField?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'basicBlock';
+          }
+        | {
+            textField?: string | null;
+            richTextField?:
+              | {
+                  [k: string]: unknown;
+                }[]
+              | null;
+            textareaField?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'basicBlockNonLocalized';
+          }
+        | {
+            richTextField?:
+              | {
+                  [k: string]: unknown;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'basicBlockRichText';
+          }
+        | {
+            textField?: string | null;
+            richTextField?:
+              | {
+                  [k: string]: unknown;
+                }[]
+              | null;
+            textareaField?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'basicBlockMixed';
+          }
+        | {
+            title?: string | null;
+            messages?:
+              | {
+                  title?: string | null;
+                  message?:
+                    | {
+                        [k: string]: unknown;
+                      }[]
+                    | null;
+                  id?: string | null;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'testBlockArrayOfRichText';
+          }
+      )[]
+    | null;
   group?: {
-    textField?: string;
-    richTextField?: {
-      [k: string]: unknown;
-    }[];
-    textareaField?: string;
+    textField?: string | null;
+    richTextField?:
+      | {
+          [k: string]: unknown;
+        }[]
+      | null;
+    textareaField?: string | null;
   };
-  tabOneTitle?: string;
-  tabOneContent?: {
-    [k: string]: unknown;
-  }[];
+  tabOneTitle?: string | null;
+  tabOneContent?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
   tabTwo: {
-    tabTwoTitle?: string;
-    tabTwoContent?: {
-      [k: string]: unknown;
-    }[];
+    tabTwoTitle?: string | null;
+    tabTwoContent?:
+      | {
+          [k: string]: unknown;
+        }[]
+      | null;
   };
-  crowdinArticleDirectory?: string | CrowdinArticleDirectory;
+  syncTranslations?: boolean | null;
+  syncAllTranslations?: boolean | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "policies".
+ */
+export interface Policy {
+  id: string;
+  title?: string | null;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  group?: {
+    array?:
+      | {
+          title?: string | null;
+          content?: {
+            root: {
+              type: string;
+              children: {
+                type: string;
+                version: number;
+                [k: string]: unknown;
+              }[];
+              direction: ('ltr' | 'rtl') | null;
+              format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+              indent: number;
+              version: number;
+            };
+            [k: string]: unknown;
+          } | null;
+          id?: string | null;
+        }[]
+      | null;
+  };
+  syncTranslations?: boolean | null;
+  syncAllTranslations?: boolean | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts".
+ */
 export interface Post {
   id: string;
-  title?: string;
-  author?: string | User;
-  publishedDate?: string;
-  category?: string | Category;
-  tags?: string[] | Tag[];
-  content?: {
-    [k: string]: unknown;
-  }[];
-  status?: "draft" | "published";
+  title?: string | null;
+  author?: (string | null) | User;
+  publishedDate?: string | null;
+  category?: (string | null) | Category;
+  tags?: (string | Tag)[] | null;
+  content?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  status?: ('draft' | 'published') | null;
   updatedAt: string;
   createdAt: string;
 }
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-posts-with-condition".
+ */
+export interface LocalizedPostsWithCondition {
+  id: string;
+  title?: string | null;
+  translateWithCrowdin?: boolean | null;
+  author?: (string | null) | User;
+  publishedDate?: string | null;
+  category?: (string | null) | Category;
+  tags?: (string | Tag)[] | null;
+  content?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  status?: ('draft' | 'published') | null;
+  syncTranslations?: boolean | null;
+  syncAllTranslations?: boolean | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-preferences".
+ */
+export interface PayloadPreference {
+  id: string;
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
+  key?: string | null;
+  value?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-migrations".
+ */
+export interface PayloadMigration {
+  id: string;
+  name?: string | null;
+  batch?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-nav".
+ */
+export interface LocalizedNav {
+  id: string;
+  items: {
+    label?: string | null;
+    id?: string | null;
+  }[];
+  syncTranslations?: boolean | null;
+  syncAllTranslations?: boolean | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nav".
+ */
 export interface Nav {
   id: string;
   items: {
-    label?: string;
-    id?: string;
+    label?: string | null;
+    id?: string | null;
   }[];
-  crowdinArticleDirectory?: string | CrowdinArticleDirectory;
-  updatedAt?: string;
-  createdAt?: string;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "statistics".
+ */
+export interface Statistic {
+  id: string;
+  users?: {
+    text?: string | null;
+    number?: number | null;
+  };
+  countries?: {
+    text?: string | null;
+    number?: number | null;
+  };
+  syncTranslations?: boolean | null;
+  syncAllTranslations?: boolean | null;
+  crowdinArticleDirectory?: (string | null) | CrowdinArticleDirectory;
+  _status?: ('draft' | 'published') | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
 }

--- a/plugin/src/lib/types.ts
+++ b/plugin/src/lib/types.ts
@@ -1,6 +1,6 @@
 import { CollectionConfig, Field, RichTextField } from "payload/types";
 import { type SlateToHtmlConfig, type HtmlToSlateConfig } from '@slate-serializers/html'
-import { CrowdinCollectionDirectory } from "./payload-types";
+import { CrowdinArticleDirectory, CrowdinCollectionDirectory } from "./payload-types";
 
 type CollectionOrGlobalConfigSlug = string
 type CollectionOrGlobalConfigObject = {
@@ -49,6 +49,10 @@ export interface PluginOptions {
 export type FieldWithName = Field & { name: string };
 
 // Type checkers
+export const isCrowdinArticleDirectory = (val: CrowdinArticleDirectory | string | undefined | null): val is CrowdinArticleDirectory => {
+  return val !== undefined && val !== null && typeof val !== 'string';
+}
+
 export const isCrowdinCollectionDirectory = (val: CrowdinCollectionDirectory | string | undefined | null): val is CrowdinCollectionDirectory => {
   return val !== undefined && val !== null && typeof val !== 'string';
 }


### PR DESCRIPTION
Builds on https://github.com/thompsonsj/payload-crowdin-sync/pull/161 by restructuring how Lexical `richText` block translations are stored in Crowdin.

Source translation files for blocks in a given Lexical field are currently stored in the same Crowdin directory as the rest of the files. A separator is used to determine which fields correspond to blocks (these are not nested fields in the regular sense, so they have their own notation).

Example: `content--blocks.65d67d2591c92e447e7472f7.highlight.content`.

This leads to very long file names (consider the case where `content` is nested further).

This change creates a directory for each Lexical field (in this case - `content`) and stores all of the translation files for embedded blocks in that folder.

## Node 18 -> 17 downgrade

Thrown off during development by `fetch` calls not being picked up by `nock` post node 18 upgrade.  `fetch` is used for translation downloads in the `translations` class. An upgrade to a beta version of `nock` solved the issue. See https://github.com/nock/nock/issues/2397.

However, this led to memory errors. Example:

```
[22:03:50] INFO (payload): Starting Payload...
  
  <--- Last few GCs --->
  
  [2137:0x640b8b0]   142748 ms: Mark-sweep (reduce) 4038.8 (4143.0) -> 4037.5 (4143.5) MB, 7772.0 / 0.0 ms  (average mu = 0.461, current mu = 0.296) allocation failure; scavenge might not succeed
  [2137:0x640b8b0]   150539 ms: Mark-sweep (reduce) 4038.7 (4143.5) -> 4037.9 (4144.0) MB, 7753.5 / 0.0 ms  (average mu = 0.277, current mu = 0.005) allocation failure; scavenge might not succeed
  
  
  <--- JS stacktrace --->
  
  FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
   1: 0xb9c1f0 node::Abort() [/opt/hostedtoolcache/node/18.20.4/x64/bin/node]
```

See failed actions/jobs for more details.

As a result, downgraded to node 17.