### PR TITLE
fix(document): check article directory exists lexical blocks

### DIFF
--- a/plugin/src/lib/api/payload-crowdin-sync/files/by-document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/by-document.ts
@@ -120,7 +120,7 @@ export class filesApiByDocument {
       const crowdinDirectory = await this.sourceFilesApi.createDirectory(
         this.projectId,
         {
-          directoryId: (parent ? parent.originalId : crowdinPayloadCollectionDirectory['originalId']) as number,
+          directoryId: (parent ? parent.originalId : crowdinPayloadCollectionDirectory?.['originalId']) as number,
           name,
           title: this.global
             ? toWords(this.collectionSlug)
@@ -132,7 +132,9 @@ export class filesApiByDocument {
       const result = await this.payload.create({
         collection: "crowdin-article-directories",
         data: {
-          crowdinCollectionDirectory: `${crowdinPayloadCollectionDirectory['id']}`,
+          ...(crowdinPayloadCollectionDirectory?.['id'] && {
+            crowdinCollectionDirectory: `${crowdinPayloadCollectionDirectory?.['id']}`,
+          }),
           originalId: crowdinDirectory.data.id,
           directoryId: crowdinDirectory.data.directoryId,
           name,
@@ -174,6 +176,10 @@ export class filesApiByDocument {
   private async findOrCreateCollectionDirectory({
     collectionSlug,
   }: IfindOrCreateCollectionDirectory) {
+    if (this.parent) {
+      return undefined
+    }
+
     let crowdinPayloadCollectionDirectory;
     // Check whether collection directory exists on Crowdin
     const query = await this.payload.find({

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -7,6 +7,7 @@ import { Config } from 'payload/config';
 
 import { isEmpty } from 'lodash';
 import {
+  getArticleDirectory,
   getFile,
   getFiles
 } from "../../helpers";
@@ -235,6 +236,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
         /**
          * Initialize Crowdin client sourceFilesApi
          */
+        const crowdinArticleDirectory = await getArticleDirectory(name, this.payload, false, this.articleDirectory)
         const apiByDocument = new filesApiByDocument(
           {
             document: {
@@ -242,6 +244,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
               id: name,
               /** Friendly name for directory */
               title: name,
+              crowdinArticleDirectory,
             },
             collectionSlug: collection.slug as keyof Config['collections'] | keyof Config['globals'],
             global: false,


### PR DESCRIPTION
Fix following parent folder structure for Lexical `richText` field blocks introduced in https://github.com/thompsonsj/payload-crowdin-sync/pull/171.