### PR TITLE
fix(document): do not update lexical blocks if empty

### DIFF
--- a/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
@@ -37,7 +37,7 @@ describe('Lexical editor with blocks', () => {
   it('builds a Crowdin HTML object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .times(4)
+      .times(3)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -301,7 +301,7 @@ describe('Lexical editor with blocks', () => {
   it('builds a Crowdin JSON object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .times(3)
+      .times(2)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -332,7 +332,7 @@ describe('Lexical editor with blocks', () => {
   it('builds a Payload update object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .thrice()
+      .twice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -607,7 +607,7 @@ describe('Lexical editor with blocks', () => {
   it('creates an HTML file for Crowdin as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .thrice()
+      .twice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -643,7 +643,7 @@ describe('Lexical editor with blocks', () => {
   it('creates HTML files for Crowdin as expected for lexical content within an array field that is embedded in a group', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .times(5)
+      .times(3)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(7)

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -123,7 +123,7 @@ describe('Lexical editor with multiple blocks', () => {
   it('builds a Crowdin HTML object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .times(4)
+      .times(3)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -358,7 +358,7 @@ describe('Lexical editor with multiple blocks', () => {
   it('builds a Crowdin JSON object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .times(3)
+      .times(2)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -389,7 +389,7 @@ describe('Lexical editor with multiple blocks', () => {
   it('builds a Payload update object as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .thrice()
+      .twice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -635,7 +635,7 @@ describe('Lexical editor with multiple blocks', () => {
   it('creates HTML files for Crowdin as expected', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .thrice()
+      .twice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)
@@ -681,7 +681,7 @@ describe('Lexical editor with multiple blocks', () => {
   it('creates HTML files for Crowdin as expected for lexical content within an array field that is embedded in a group', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .times(5)
+      .times(3)
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(7)
@@ -748,7 +748,7 @@ describe('Lexical editor with multiple blocks', () => {
   it('updates a Payload article with a rich text field that uses the Lexical editor with multiple blocks with a translation received from Crowdin', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
-      .times(3)
+      .twice()
       .reply(200, mockClient.createDirectory({}))
       .post(`/api/v2/storages`)
       .times(4)

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -231,7 +231,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
         html = await convertLexicalToHtml(value, editorConfig)
         // no need to detect change - this has already been done on the field's JSON object
         const blockContent = value && extractLexicalBlockContent(value.root)
-        if (blockContent) {
+        if (blockContent && blockContent.length > 0) {
           // directory name must be unique from file names - Crowdin API
           const folderName = `${this.pluginOptions.lexicalBlockFolderPrefix}${name}`
           const blockConfig = getLexicalBlockFields(editorConfig)


### PR DESCRIPTION
If there is no block content, do not update Lexical blocks folders.

Could be improved - possibly do the check on block config instead. A scenario is possible where block content exists but config doesn't because it was reconfigured at a later date.