### PR TITLE
fix(pluginfields): additional flag for translation sync checkboxes

### DIFF
--- a/dev/src/lib/tests/helpers/nock.ts
+++ b/dev/src/lib/tests/helpers/nock.ts
@@ -1,0 +1,30 @@
+import nock from "nock";
+import { mockCrowdinClient } from "plugin/src/lib/api/mock/crowdin-api-responses";
+import { pluginConfig } from "../helpers/plugin-config"
+
+const pluginOptions = pluginConfig()
+const mockClient = mockCrowdinClient(pluginOptions)
+
+export function nockCreateSourceTranslationFiles({
+  createProjectDirectory = false,
+  fileCount = 1,
+}) {
+  const directoryCount = createProjectDirectory ? 2 : 1
+
+  return nock('https://api.crowdin.com')
+  .post(
+    `/api/v2/projects/${pluginOptions.projectId}/directories`
+  )
+  .times(directoryCount)
+  .reply(200, mockClient.createDirectory({}))
+  .post(
+    `/api/v2/storages`
+  )
+  .times(fileCount)
+  .reply(200, mockClient.addStorage())
+  .post(
+    `/api/v2/projects/${pluginOptions.projectId}/files`
+  )
+  .times(fileCount)
+  .reply(200, mockClient.createFile({}))
+}

--- a/dev/src/lib/tests/translations/receive/virtual-fields.test.ts
+++ b/dev/src/lib/tests/translations/receive/virtual-fields.test.ts
@@ -4,6 +4,8 @@ import nock from "nock";
 import { mockCrowdinClient } from "plugin/src/lib/api/mock/crowdin-api-responses";
 import { pluginConfig } from "../../helpers/plugin-config"
 
+import { nockCreateSourceTranslationFiles } from "../../helpers/nock"
+
 /**
  * Test virtual fields
  *
@@ -44,20 +46,9 @@ describe("Virtual fields", () => {
 
   describe("No database storage", () => {
     it("does not store syncTranslations", async () => {
-      nock('https://api.crowdin.com')
-        .post(
-          `/api/v2/projects/${pluginOptions.projectId}/directories`
-        )
-        .twice()
-        .reply(200, mockClient.createDirectory({}))
-        .post(
-          `/api/v2/storages`
-        )
-        .reply(200, mockClient.addStorage())
-        .post(
-          `/api/v2/projects/${pluginOptions.projectId}/files`
-        )
-        .reply(200, mockClient.createFile({}))
+      nockCreateSourceTranslationFiles({
+        createProjectDirectory: true,
+      })
 
       const post = await payload.create({
         collection: "localized-posts",
@@ -75,19 +66,7 @@ describe("Virtual fields", () => {
     });
 
     it("does not store syncAllTranslations", async () => {
-      nock('https://api.crowdin.com')
-        .post(
-          `/api/v2/projects/${pluginOptions.projectId}/directories`
-        )
-        .reply(200, mockClient.createDirectory({}))
-        .post(
-          `/api/v2/storages`
-        )
-        .reply(200, mockClient.addStorage())
-        .post(
-          `/api/v2/projects/${pluginOptions.projectId}/files`
-        )
-        .reply(200, mockClient.createFile({}))
+      nockCreateSourceTranslationFiles({})
 
       const post = await payload.create({
         collection: "localized-posts",

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -67,7 +67,7 @@ export const pluginCollectionOrGlobalFields = ({
         }],
         afterChange: [async ({ context, req }) => {
           // type check context, if valid we can safely assume translation updates are desired
-          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && Array.isArray(context['excludeLocales']) && context["syncTranslations"])
+          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && Array.isArray(context['excludeLocales']) && typeof context["syncTranslations"] === 'boolean')
             await updatePayloadTranslation({
               articleDirectoryId: context['articleDirectoryId'],
               pluginOptions,
@@ -108,7 +108,7 @@ export const pluginCollectionOrGlobalFields = ({
         }],
         afterChange: [async ({ context, req }) => {
           // type check context, if valid we can safely assume translation updates are desired
-          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && context["syncAllTranslations"])
+          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && typeof context["syncAllTranslations"] === 'boolean')
             await updatePayloadTranslation({
               articleDirectoryId: context['articleDirectoryId'],
               pluginOptions,

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -59,7 +59,7 @@ export const pluginCollectionOrGlobalFields = ({
             context['articleDirectoryId'] = typeof siblingData["crowdinArticleDirectory"] === 'string' ? siblingData["crowdinArticleDirectory"] : siblingData["crowdinArticleDirectory"].id
             context['draft'] = draft
             context['excludeLocales'] = excludeLocales
-            
+            context["syncTranslations"] = true
           }
           // Mutate the sibling data to prevent DB storage
           // eslint-disable-next-line no-param-reassign
@@ -67,7 +67,7 @@ export const pluginCollectionOrGlobalFields = ({
         }],
         afterChange: [async ({ context, req }) => {
           // type check context, if valid we can safely assume translation updates are desired
-          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && Array.isArray(context['excludeLocales']))
+          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && Array.isArray(context['excludeLocales']) && context["syncTranslations"])
             await updatePayloadTranslation({
               articleDirectoryId: context['articleDirectoryId'],
               pluginOptions,
@@ -100,6 +100,7 @@ export const pluginCollectionOrGlobalFields = ({
 
             context['articleDirectoryId'] = typeof siblingData["crowdinArticleDirectory"] === 'string' ? siblingData["crowdinArticleDirectory"] : siblingData["crowdinArticleDirectory"].id
             context['draft'] = draft
+            context["syncAllTranslations"] = true
           }
           // Mutate the sibling data to prevent DB storage
           // eslint-disable-next-line no-param-reassign
@@ -107,7 +108,7 @@ export const pluginCollectionOrGlobalFields = ({
         }],
         afterChange: [async ({ context, req }) => {
           // type check context, if valid we can safely assume translation updates are desired
-          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean')
+          if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && context["syncAllTranslations"])
             await updatePayloadTranslation({
               articleDirectoryId: context['articleDirectoryId'],
               pluginOptions,


### PR DESCRIPTION
Untested fix for https://github.com/thompsonsj/payload-crowdin-sync/issues/187.

Will be manually tested in a production install.

End to end tests are required for testing virtual fields and we don't have end to end testing configured yet.