### PR TITLE
feat(translations): receive translations for lexical blocks

### DIFF
--- a/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-blocks.test.ts
@@ -636,7 +636,7 @@ describe('Lexical editor with blocks', () => {
       (file) => file.field === 'content'
     );
     expect(contentHtmlFile?.fileData?.html).toMatchInlineSnapshot(
-      `"<h2>Lexical editor content</h2><p>This is editable <strong>rich</strong> text, <em>much</em> better than a <code><textarea></code>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p>Try it out for yourself!</p><p></p><span data-block-id=6582d48f2037fb3ca72ed2cf></span><p></p>"`
+      `"<h2>Lexical editor content</h2><p>This is editable <strong>rich</strong> text, <em>much</em> better than a <code><textarea></code>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p>Try it out for yourself!</p><p></p><span data-block-id=6582d48f2037fb3ca72ed2cf data-block-type=highlight></span><p></p>"`
     );
   });
 
@@ -652,7 +652,7 @@ describe('Lexical editor with blocks', () => {
       .times(7)
       .reply(200, mockClient.createFile({}));
 
-    const policy: Policy = await payload.create({
+    const policy: Policy = (await payload.create({
       collection: 'policies',
       data: {
         group: {
@@ -668,7 +668,7 @@ describe('Lexical editor with blocks', () => {
           ],
         },
       },
-    }) as any;
+    })) as any;
 
     const arrayField = isDefined(policy['group']?.['array'])
       ? policy['group']?.['array']
@@ -690,18 +690,26 @@ describe('Lexical editor with blocks', () => {
     expect(
       crowdinFiles.find((file) => file.name === 'fields.json')
     ).toBeDefined();
-    
-    const fileOneCrowdinFiles = await getFilesByDocumentID(`${pluginOptions.lexicalBlockFolderPrefix}group.array.${ids[0]}.content`, payload, policy.crowdinArticleDirectory as CrowdinArticleDirectory);
-    const fileTwoCrowdinFiles = await getFilesByDocumentID(`${pluginOptions.lexicalBlockFolderPrefix}group.array.${ids[1]}.content`, payload, policy.crowdinArticleDirectory as CrowdinArticleDirectory);
+
+    const fileOneCrowdinFiles = await getFilesByDocumentID(
+      `${pluginOptions.lexicalBlockFolderPrefix}group.array.${ids[0]}.content`,
+      payload,
+      policy.crowdinArticleDirectory as CrowdinArticleDirectory
+    );
+    const fileTwoCrowdinFiles = await getFilesByDocumentID(
+      `${pluginOptions.lexicalBlockFolderPrefix}group.array.${ids[1]}.content`,
+      payload,
+      policy.crowdinArticleDirectory as CrowdinArticleDirectory
+    );
     expect(fileOneCrowdinFiles.length).toEqual(2);
     expect(fileTwoCrowdinFiles.length).toEqual(2);
 
     expect(htmlFileOne?.fileData?.html).toMatchInlineSnapshot(
-      `"<h2>Lexical editor content</h2><p>This is editable <strong>rich</strong> text, <em>much</em> better than a <code><textarea></code>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p>Try it out for yourself!</p><p></p><span data-block-id=6582d48f2037fb3ca72ed2cf></span><p></p>"`
+      `"<h2>Lexical editor content</h2><p>This is editable <strong>rich</strong> text, <em>much</em> better than a <code><textarea></code>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p>Try it out for yourself!</p><p></p><span data-block-id=6582d48f2037fb3ca72ed2cf data-block-type=highlight></span><p></p>"`
     );
 
     expect(htmlFileTwo?.fileData?.html).toMatchInlineSnapshot(
-      `"<h2>Lexical editor content</h2><p>This is editable <strong>rich</strong> text, <em>much</em> better than a <code><textarea></code>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p>Try it out for yourself!</p><p></p><span data-block-id=6582d48f2037fb3ca72ed2cf></span><p></p>"`
+      `"<h2>Lexical editor content</h2><p>This is editable <strong>rich</strong> text, <em>much</em> better than a <code><textarea></code>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p>Try it out for yourself!</p><p></p><span data-block-id=6582d48f2037fb3ca72ed2cf data-block-type=highlight></span><p></p>"`
     );
   });
 });

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -1010,8 +1010,8 @@ describe('Lexical editor with multiple blocks', () => {
       })
       .reply(
         200,
-        `<p>Exemple de contenu pour un champ de texte enrichi lexical avec plusieurs blocs.</p><span data-block-id=65d67d2591c92e447e7472f7}></span><p>Une liste à puces entre certains blocs composée de:</p><ul class="bullet"><li value=1>un élément de liste à puces ; et</li><li value=2>
-      un autre!</li></ul><span data-block-id=65d67d8191c92e447e7472f8}></span><span data-block-id=65d67e2291c92e447e7472f9}></span><ul class="bullet"><li value=1></li></ul>`
+        `<p>Exemple de contenu pour un champ de texte enrichi lexical avec plusieurs blocs.</p><span data-block-id=65d67d2591c92e447e7472f7 data-block-type=cta></span><p>Une liste à puces entre certains blocs composée de:</p><ul class="bullet"><li value=1>un élément de liste à puces ; et</li><li value=2>
+      un autre!</li></ul><span data-block-id=65d67d8191c92e447e7472f8 data-block-type=highlight></span><span data-block-id=65d67e2291c92e447e7472f9 data-block-type=imageText></span><ul class="bullet"><li value=1></li></ul>`
       );
 
     const policy = await payload.create({

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -888,6 +888,45 @@ describe('Lexical editor with multiple blocks', () => {
         targetLanguageId: 'de',
       })
       .reply(200, {})
+      // de - file 2 get translation
+      .post(
+        `/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56642}`,
+        {
+          targetLanguageId: 'de',
+        }
+      )
+      .reply(200, mockClient.buildProjectFileTranslation({
+        url: `https://api.crowdin.com/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download?targetLanguageId=de`
+      }))
+      .get(
+        `/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download`
+      )
+      .query({
+        targetLanguageId: 'de',
+      })
+      .reply(200, {
+        "blocks": {
+          "65d67d2591c92e447e7472f7": {
+            "cta": {
+              "text": "Download payload-crowdin-sync on npm!",
+              "href": "https://www.npmjs.com/package/payload-crowdin-sync"
+            }
+          },
+          "65d67d8191c92e447e7472f8": {
+            "highlight": {
+              "heading": {
+                "title": "Blocks are extracted into their own fields",
+                "preTitle": "How the plugin handles blocks in the Lexical editor"
+              }
+            }
+          },
+          "65d67e2291c92e447e7472f9": {
+            "imageText": {
+              "title": "Testing a range of fields"
+            }
+          }
+        }
+      })
       // de - file 3 get translation
       /**
       .post(
@@ -934,7 +973,6 @@ describe('Lexical editor with multiple blocks', () => {
       })
       .reply(200, {})
       // fr - file 2 get translation
-      /**
       .post(
         `/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56642}`,
         {
@@ -950,8 +988,29 @@ describe('Lexical editor with multiple blocks', () => {
       .query({
         targetLanguageId: 'fr',
       })
-      .reply(200, {})
-      */
+      .reply(200, {
+        "blocks": {
+          "65d67d2591c92e447e7472f7": {
+            "cta": {
+              "text": "Download payload-crowdin-sync on npm!",
+              "href": "https://www.npmjs.com/package/payload-crowdin-sync"
+            }
+          },
+          "65d67d8191c92e447e7472f8": {
+            "highlight": {
+              "heading": {
+                "title": "Blocks are extracted into their own fields",
+                "preTitle": "How the plugin handles blocks in the Lexical editor"
+              }
+            }
+          },
+          "65d67e2291c92e447e7472f9": {
+            "imageText": {
+              "title": "Testing a range of fields"
+            }
+          }
+        }
+      })
       // fr - file 3 get translation
       /**
       .post(

--- a/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -704,7 +704,7 @@ describe('Lexical editor with multiple blocks', () => {
       (file) => file.field === 'content'
     );
     expect(contentHtmlFile?.fileData?.html).toMatchInlineSnapshot(
-      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span data-block-id=65d67d2591c92e447e7472f7></span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span data-block-id=65d67d8191c92e447e7472f8></span><span data-block-id=65d67e2291c92e447e7472f9></span><ul class="bullet"><li value=1></li></ul>"`
+      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span data-block-id=65d67d2591c92e447e7472f7 data-block-type=cta></span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span data-block-id=65d67d8191c92e447e7472f8 data-block-type=highlight></span><span data-block-id=65d67e2291c92e447e7472f9 data-block-type=imageText></span><ul class="bullet"><li value=1></li></ul>"`
     );
     const contentBlocksCrowdinFiles = await getFilesByDocumentID(
       `${pluginOptions.lexicalBlockFolderPrefix}content`,
@@ -788,11 +788,11 @@ describe('Lexical editor with multiple blocks', () => {
     expect(fileTwoCrowdinFiles.length).toEqual(2);
 
     expect(htmlFileOne?.fileData?.html).toMatchInlineSnapshot(
-      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span data-block-id=65d67d2591c92e447e7472f7></span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span data-block-id=65d67d8191c92e447e7472f8></span><span data-block-id=65d67e2291c92e447e7472f9></span><ul class="bullet"><li value=1></li></ul>"`
+      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span data-block-id=65d67d2591c92e447e7472f7 data-block-type=cta></span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span data-block-id=65d67d8191c92e447e7472f8 data-block-type=highlight></span><span data-block-id=65d67e2291c92e447e7472f9 data-block-type=imageText></span><ul class="bullet"><li value=1></li></ul>"`
     );
 
     expect(htmlFileTwo?.fileData?.html).toMatchInlineSnapshot(
-      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span data-block-id=65d67d2591c92e447e7472f7></span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span data-block-id=65d67d8191c92e447e7472f8></span><span data-block-id=65d67e2291c92e447e7472f9></span><ul class="bullet"><li value=1></li></ul>"`
+      `"<p>Sample content for a Lexical rich text field with multiple blocks.</p><span data-block-id=65d67d2591c92e447e7472f7 data-block-type=cta></span><p>A bulleted list in-between some blocks consisting of:</p><ul class="bullet"><li value=1>one bullet list item; and</li><li value=2>another!</li></ul><span data-block-id=65d67d8191c92e447e7472f8 data-block-type=highlight></span><span data-block-id=65d67e2291c92e447e7472f9 data-block-type=imageText></span><ul class="bullet"><li value=1></li></ul>"`
     );
   });
 
@@ -890,45 +890,53 @@ describe('Lexical editor with multiple blocks', () => {
       .reply(200, {})
       // de - file 2 get translation
       .post(
-        `/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56642}`,
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/files/${56642}`,
         {
           targetLanguageId: 'de',
         }
       )
-      .reply(200, mockClient.buildProjectFileTranslation({
-        url: `https://api.crowdin.com/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download?targetLanguageId=de`
-      }))
+      .reply(
+        200,
+        mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${
+            pluginOptions.projectId
+          }/translations/builds/${56642}/download?targetLanguageId=de`,
+        })
+      )
       .get(
-        `/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download`
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${56642}/download`
       )
       .query({
         targetLanguageId: 'de',
       })
       .reply(200, {
-        "blocks": {
-          "65d67d2591c92e447e7472f7": {
-            "cta": {
-              "text": "Download payload-crowdin-sync on npm!",
-              "href": "https://www.npmjs.com/package/payload-crowdin-sync"
-            }
+        blocks: {
+          '65d67d2591c92e447e7472f7': {
+            cta: {
+              text: 'Laden Sie payload-crowdin-sync auf npm herunter!',
+              href: 'https://www.npmjs.com/package/payload-crowdin-sync',
+            },
           },
-          "65d67d8191c92e447e7472f8": {
-            "highlight": {
-              "heading": {
-                "title": "Blocks are extracted into their own fields",
-                "preTitle": "How the plugin handles blocks in the Lexical editor"
-              }
-            }
+          '65d67d8191c92e447e7472f8': {
+            highlight: {
+              heading: {
+                title: 'Blöcke werden in ihre eigenen Felder extrahiert',
+                preTitle: 'Wie das Plugin Blöcke im Lexikaleditor behandelt',
+              },
+            },
           },
-          "65d67e2291c92e447e7472f9": {
-            "imageText": {
-              "title": "Testing a range of fields"
-            }
-          }
-        }
+          '65d67e2291c92e447e7472f9': {
+            imageText: {
+              title: 'Testen einer Reihe von Feldern',
+            },
+          },
+        },
       })
       // de - file 3 get translation
-      /**
       .post(
         `/api/v2/projects/${
           pluginOptions.projectId
@@ -942,10 +950,21 @@ describe('Lexical editor with multiple blocks', () => {
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
-          }/translations/builds/${56643}/download?targetLanguageId=fr`,
+          }/translations/builds/${56643}/download?targetLanguageId=de`,
         })
       )
-      */
+      .get(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${56643}/download`
+      )
+      .query({
+        targetLanguageId: 'de',
+      })
+      .reply(
+        200,
+        '<p>Das Plugin analysiert Ihre Blockkonfiguration für den Lexical-Rich-Text-Editor. Es extrahiert alle Blockwerte aus dem Rich-Text-Feld und behandelt diese Konfigurations-/Datenkombination dann als reguläres „Blocks“-Feld.</p<p>>Im HTML werden Markierungen platziert und dieser Inhalt wird bei der Übersetzung an der richtigen Stelle wiederhergestellt.</p>'
+      )
       // fr - file 1 get translation
       .post(
         `/api/v2/projects/${
@@ -974,45 +993,55 @@ describe('Lexical editor with multiple blocks', () => {
       .reply(200, {})
       // fr - file 2 get translation
       .post(
-        `/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56642}`,
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/files/${56642}`,
         {
           targetLanguageId: 'fr',
         }
       )
-      .reply(200, mockClient.buildProjectFileTranslation({
-        url: `https://api.crowdin.com/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download?targetLanguageId=fr`
-      }))
+      .reply(
+        200,
+        mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${
+            pluginOptions.projectId
+          }/translations/builds/${56642}/download?targetLanguageId=fr`,
+        })
+      )
       .get(
-        `/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download`
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${56642}/download`
       )
       .query({
         targetLanguageId: 'fr',
       })
       .reply(200, {
-        "blocks": {
-          "65d67d2591c92e447e7472f7": {
-            "cta": {
-              "text": "Download payload-crowdin-sync on npm!",
-              "href": "https://www.npmjs.com/package/payload-crowdin-sync"
-            }
+        blocks: {
+          '65d67d2591c92e447e7472f7': {
+            cta: {
+              text: 'Téléchargez payload-crowdin-sync sur npm!',
+              href: 'https://www.npmjs.com/package/payload-crowdin-sync',
+            },
           },
-          "65d67d8191c92e447e7472f8": {
-            "highlight": {
-              "heading": {
-                "title": "Blocks are extracted into their own fields",
-                "preTitle": "How the plugin handles blocks in the Lexical editor"
-              }
-            }
+          '65d67d8191c92e447e7472f8': {
+            highlight: {
+              heading: {
+                title: 'Les blocs sont extraits dans leurs propres champs',
+                preTitle:
+                  "Comment le plugin gère les blocs dans l'éditeur lexical",
+              },
+            },
           },
-          "65d67e2291c92e447e7472f9": {
-            "imageText": {
-              "title": "Testing a range of fields"
-            }
-          }
-        }
+          '65d67e2291c92e447e7472f9': {
+            imageText: {
+              title: 'Tester une gamme de domaines',
+            },
+          },
+        },
       })
       // fr - file 3 get translation
-      /**
+
       .post(
         `/api/v2/projects/${
           pluginOptions.projectId
@@ -1034,14 +1063,14 @@ describe('Lexical editor with multiple blocks', () => {
           pluginOptions.projectId
         }/translations/builds/${56643}/download`
       )
-      .times(2)
       .query({
         targetLanguageId: 'fr',
       })
-        
-      // all files have the same fileID - we provide the same response for each translation request, therefore only one file can be tested in each test
-      .reply(200, "<p>Poste d'essai</p>")
-      */
+      .reply(
+        200,
+        "<p>Le plugin analyse la configuration de votre bloc pour l'éditeur de texte enrichi lexical. Il extrait toutes les valeurs de bloc du champ de texte enrichi, puis traite cette combinaison configuration/données comme un champ « blocs » normal.</p<p>>Les marqueurs sont placés dans le code HTML et ce contenu est restauré au bon endroit lors de la traduction.</p>"
+      )
+
       // fr - file 4 get translation
       .post(
         `/api/v2/projects/${
@@ -1154,6 +1183,17 @@ describe('Lexical editor with multiple blocks', () => {
               "version": 1,
             },
             {
+              "fields": {
+                "blockType": "cta",
+                "href": "https://www.npmjs.com/package/payload-crowdin-sync",
+                "id": "65d67d2591c92e447e7472f7",
+                "text": "Téléchargez payload-crowdin-sync sur npm!",
+              },
+              "format": "",
+              "type": "block",
+              "version": 2,
+            },
+            {
               "children": [
                 {
                   "detail": 0,
@@ -1220,6 +1260,58 @@ describe('Lexical editor with multiple blocks', () => {
               "tag": "ul",
               "type": "list",
               "version": 1,
+            },
+            {
+              "fields": {
+                "blockType": "highlight",
+                "content": {
+                  "root": {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "detail": 0,
+                            "format": 0,
+                            "mode": "normal",
+                            "style": "",
+                            "text": "Le plugin analyse la configuration de votre bloc pour l'éditeur de texte enrichi lexical. Il extrait toutes les valeurs de bloc du champ de texte enrichi, puis traite cette combinaison configuration/données comme un champ « blocs » normal.>Les marqueurs sont placés dans le code HTML et ce contenu est restauré au bon endroit lors de la traduction.",
+                            "type": "text",
+                            "version": 1,
+                          },
+                        ],
+                        "direction": "ltr",
+                        "format": "",
+                        "indent": 0,
+                        "type": "paragraph",
+                        "version": 1,
+                      },
+                    ],
+                    "direction": "ltr",
+                    "format": "",
+                    "indent": 0,
+                    "type": "root",
+                    "version": 1,
+                  },
+                },
+                "heading": {
+                  "preTitle": "Comment le plugin gère les blocs dans l'éditeur lexical",
+                  "title": "Les blocs sont extraits dans leurs propres champs",
+                },
+                "id": "65d67d8191c92e447e7472f8",
+              },
+              "format": "",
+              "type": "block",
+              "version": 2,
+            },
+            {
+              "fields": {
+                "blockType": "imageText",
+                "id": "65d67e2291c92e447e7472f9",
+                "title": "Tester une gamme de domaines",
+              },
+              "format": "",
+              "type": "block",
+              "version": 2,
             },
             {
               "children": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7503,6 +7503,7 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz",
       "integrity": "sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.2",
@@ -7543,6 +7544,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7558,6 +7560,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7573,6 +7576,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7588,6 +7592,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7603,6 +7608,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7618,6 +7624,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7633,6 +7640,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7648,6 +7656,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7663,6 +7672,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7678,6 +7688,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7736,6 +7747,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
       "integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
+      "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
@@ -15461,16 +15473,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "peer": true,
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -15783,23 +15785,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -15833,24 +15818,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/jest-circus/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.5.1",
@@ -17738,27 +17705,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.13.1.tgz",
       "integrity": "sha512-jaqRYzVEfBKbX4FwYpd/g+MyOjRaraAel0iQsTrwvx3hyN0bswUZuzb6H6nGlFSjcdrc77wKpyKwoWj4aUd+Bw=="
-    },
-    "node_modules/lib0": {
-      "version": "0.2.94",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.94.tgz",
-      "integrity": "sha512-hZ3p54jL4Wpu7IOg26uC7dnEWiMyNlUrb9KoG7+xYs45WkQwpVvKFndVq2+pqLYKe1u8Fp3+zAfZHVvTK34PvQ==",
-      "peer": true,
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
     },
     "node_modules/lines-and-columns": {
       "version": "2.0.4",
@@ -24682,6 +24628,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -25828,23 +25775,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yjs": {
-      "version": "13.6.18",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
-      "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
-      "peer": true,
-      "dependencies": {
-        "lib0": "^0.2.86"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -26832,8 +26762,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -28233,8 +28162,7 @@
     "@csstools/cascade-layer-name-parser": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-1.0.6.tgz",
-      "integrity": "sha512-HkxRNs6ZIV0VjLFw6k5G8K35vd9r+O8B1Vr+QVD8M5Y44eQxyHtc42BdF74FQatXACPnitOR1+sRx2oWdnKTQw==",
-      "requires": {}
+      "integrity": "sha512-HkxRNs6ZIV0VjLFw6k5G8K35vd9r+O8B1Vr+QVD8M5Y44eQxyHtc42BdF74FQatXACPnitOR1+sRx2oWdnKTQw=="
     },
     "@csstools/color-helpers": {
       "version": "4.0.0",
@@ -28244,8 +28172,7 @@
     "@csstools/css-calc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-1.1.5.tgz",
-      "integrity": "sha512-UhI5oSRAUtTHY3MyGahqn0ZzQOHVoPpfvUcOmYipAZ1rILAvCBoyiLSsa/clv1Xxct0SMKIq93KO5Bfl1cb6tQ==",
-      "requires": {}
+      "integrity": "sha512-UhI5oSRAUtTHY3MyGahqn0ZzQOHVoPpfvUcOmYipAZ1rILAvCBoyiLSsa/clv1Xxct0SMKIq93KO5Bfl1cb6tQ=="
     },
     "@csstools/css-color-parser": {
       "version": "1.5.0",
@@ -28259,8 +28186,7 @@
     "@csstools/css-parser-algorithms": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.4.0.tgz",
-      "integrity": "sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg==",
-      "requires": {}
+      "integrity": "sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg=="
     },
     "@csstools/css-tokenizer": {
       "version": "2.2.2",
@@ -28270,8 +28196,7 @@
     "@csstools/media-query-list-parser": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.6.tgz",
-      "integrity": "sha512-R6AKl9vaU0It7D7TR2lQn0pre5aQfdeqHRePlaRCY8rHL3l9eVlNRpsEVDKFi/zAjzv68CxH2M5kqbhPFPKjvw==",
-      "requires": {}
+      "integrity": "sha512-R6AKl9vaU0It7D7TR2lQn0pre5aQfdeqHRePlaRCY8rHL3l9eVlNRpsEVDKFi/zAjzv68CxH2M5kqbhPFPKjvw=="
     },
     "@csstools/postcss-cascade-layers": {
       "version": "4.0.2",
@@ -28374,8 +28299,7 @@
     "@csstools/postcss-logical-float-and-clear": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-float-and-clear/-/postcss-logical-float-and-clear-2.0.1.tgz",
-      "integrity": "sha512-SsrWUNaXKr+e/Uo4R/uIsqJYt3DaggIh/jyZdhy/q8fECoJSKsSMr7nObSLdvoULB69Zb6Bs+sefEIoMG/YfOA==",
-      "requires": {}
+      "integrity": "sha512-SsrWUNaXKr+e/Uo4R/uIsqJYt3DaggIh/jyZdhy/q8fECoJSKsSMr7nObSLdvoULB69Zb6Bs+sefEIoMG/YfOA=="
     },
     "@csstools/postcss-logical-resize": {
       "version": "2.0.1",
@@ -28500,14 +28424,12 @@
     "@csstools/postcss-unset-value": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-3.0.1.tgz",
-      "integrity": "sha512-dbDnZ2ja2U8mbPP0Hvmt2RMEGBiF1H7oY6HYSpjteXJGihYwgxgTr6KRbbJ/V6c+4wd51M+9980qG4gKVn5ttg==",
-      "requires": {}
+      "integrity": "sha512-dbDnZ2ja2U8mbPP0Hvmt2RMEGBiF1H7oY6HYSpjteXJGihYwgxgTr6KRbbJ/V6c+4wd51M+9980qG4gKVn5ttg=="
     },
     "@csstools/selector-specificity": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.1.tgz",
-      "integrity": "sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww==",
-      "requires": {}
+      "integrity": "sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww=="
     },
     "@cypress/request": {
       "version": "3.0.1",
@@ -28775,8 +28697,7 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "requires": {}
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw=="
     },
     "@emotion/utils": {
       "version": "1.2.1",
@@ -28866,14 +28787,12 @@
     "@faceless-ui/scroll-info": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@faceless-ui/scroll-info/-/scroll-info-1.3.0.tgz",
-      "integrity": "sha512-X+doJMzQqyVGpwV/YgXUAalNWepP2W8ThgZspKZLFG43zTYLVTU17BYCjjY+ggKuA3b0W3JyXZ2M8f247AdmHw==",
-      "requires": {}
+      "integrity": "sha512-X+doJMzQqyVGpwV/YgXUAalNWepP2W8ThgZspKZLFG43zTYLVTU17BYCjjY+ggKuA3b0W3JyXZ2M8f247AdmHw=="
     },
     "@faceless-ui/window-info": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@faceless-ui/window-info/-/window-info-2.1.1.tgz",
-      "integrity": "sha512-gMAgda7beR4CNpBIXjgRVn97ek0LG3PAj9lxmoYdg574IEzLFZAh3eAYtTaS2XLKgb4+IHhsuBzlGmHbeOo2Aw==",
-      "requires": {}
+      "integrity": "sha512-gMAgda7beR4CNpBIXjgRVn97ek0LG3PAj9lxmoYdg574IEzLFZAh3eAYtTaS2XLKgb4+IHhsuBzlGmHbeOo2Aw=="
     },
     "@floating-ui/core": {
       "version": "1.5.2",
@@ -29570,8 +29489,7 @@
     "@lexical/dragon": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.13.1.tgz",
-      "integrity": "sha512-aNlqfif4//jW7gOxbBgdrbDovU6m3EwQrUw+Y/vqRkY+sWmloyAUeNwCPH1QP3Q5cvfolzOeN5igfBljsFr+1g==",
-      "requires": {}
+      "integrity": "sha512-aNlqfif4//jW7gOxbBgdrbDovU6m3EwQrUw+Y/vqRkY+sWmloyAUeNwCPH1QP3Q5cvfolzOeN5igfBljsFr+1g=="
     },
     "@lexical/hashtag": {
       "version": "0.13.1",
@@ -29584,8 +29502,7 @@
     "@lexical/headless": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/headless/-/headless-0.13.1.tgz",
-      "integrity": "sha512-W2mLUuWPrsyf2n73NWM8nKiBI11lEpVVzKE0OzMsjTskv5+AAMaeu1wQ7M1508vKdCcUZwA6AOh3To/hstLEpw==",
-      "requires": {}
+      "integrity": "sha512-W2mLUuWPrsyf2n73NWM8nKiBI11lEpVVzKE0OzMsjTskv5+AAMaeu1wQ7M1508vKdCcUZwA6AOh3To/hstLEpw=="
     },
     "@lexical/history": {
       "version": "0.13.1",
@@ -29644,20 +29561,17 @@
     "@lexical/offset": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.13.1.tgz",
-      "integrity": "sha512-j/RZcztJ7dyTrfA2+C3yXDzWDXV+XmMpD5BYeQCEApaHvlo20PHt1BISk7RcrnQW8PdzGvpKblRWf//c08LS9w==",
-      "requires": {}
+      "integrity": "sha512-j/RZcztJ7dyTrfA2+C3yXDzWDXV+XmMpD5BYeQCEApaHvlo20PHt1BISk7RcrnQW8PdzGvpKblRWf//c08LS9w=="
     },
     "@lexical/overflow": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.13.1.tgz",
-      "integrity": "sha512-Uw34j+qG2UJRCIR+bykfFMduFk7Pc4r/kNt8N1rjxGuGXAsreTVch1iOhu7Ev6tJgkURsduKuaJCAi7iHnKl7g==",
-      "requires": {}
+      "integrity": "sha512-Uw34j+qG2UJRCIR+bykfFMduFk7Pc4r/kNt8N1rjxGuGXAsreTVch1iOhu7Ev6tJgkURsduKuaJCAi7iHnKl7g=="
     },
     "@lexical/plain-text": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.13.1.tgz",
-      "integrity": "sha512-4j5KAsMKUvJ8LhVDSS4zczbYXzdfmgYSAVhmqpSnJtud425Nk0TAfpUBLFoivxZB7KMoT1LGWQZvd47IvJPvtA==",
-      "requires": {}
+      "integrity": "sha512-4j5KAsMKUvJ8LhVDSS4zczbYXzdfmgYSAVhmqpSnJtud425Nk0TAfpUBLFoivxZB7KMoT1LGWQZvd47IvJPvtA=="
     },
     "@lexical/react": {
       "version": "0.13.1",
@@ -29697,14 +29611,12 @@
     "@lexical/rich-text": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.13.1.tgz",
-      "integrity": "sha512-HliB9Ync06mv9DBg/5j0lIsTJp+exLHlaLJe+n8Zq1QNTzZzu2LsIT/Crquk50In7K/cjtlaQ/d5RB0LkjMHYg==",
-      "requires": {}
+      "integrity": "sha512-HliB9Ync06mv9DBg/5j0lIsTJp+exLHlaLJe+n8Zq1QNTzZzu2LsIT/Crquk50In7K/cjtlaQ/d5RB0LkjMHYg=="
     },
     "@lexical/selection": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.13.1.tgz",
-      "integrity": "sha512-Kt9eSwjxPznj7yzIYipu9yYEgmRJhHiq3DNxHRxInYcZJWWNNHum2xKyxwwcN8QYBBzgfPegfM/geqQEJSV1lQ==",
-      "requires": {}
+      "integrity": "sha512-Kt9eSwjxPznj7yzIYipu9yYEgmRJhHiq3DNxHRxInYcZJWWNNHum2xKyxwwcN8QYBBzgfPegfM/geqQEJSV1lQ=="
     },
     "@lexical/table": {
       "version": "0.13.1",
@@ -29717,8 +29629,7 @@
     "@lexical/text": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.13.1.tgz",
-      "integrity": "sha512-NYy3TZKt3qzReDwN2Rr5RxyFlg84JjXP2JQGMrXSSN7wYe73ysQIU6PqdVrz4iZkP+w34F3pl55dJ24ei3An9w==",
-      "requires": {}
+      "integrity": "sha512-NYy3TZKt3qzReDwN2Rr5RxyFlg84JjXP2JQGMrXSSN7wYe73ysQIU6PqdVrz4iZkP+w34F3pl55dJ24ei3An9w=="
     },
     "@lexical/utils": {
       "version": "0.13.1",
@@ -31122,8 +31033,7 @@
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@swc-node/core/-/core-1.13.3.tgz",
       "integrity": "sha512-OGsvXIid2Go21kiNqeTIn79jcaX4l0G93X2rAnas4LFoDyA9wAwVK7xZdm+QsKoMn5Mus2yFLCc4OtX2dD/PWA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@swc-node/register": {
       "version": "1.9.2",
@@ -31165,6 +31075,7 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz",
       "integrity": "sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==",
+      "dev": true,
       "requires": {
         "@swc/core-darwin-arm64": "1.5.7",
         "@swc/core-darwin-x64": "1.5.7",
@@ -31184,60 +31095,70 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.7.tgz",
       "integrity": "sha512-bZLVHPTpH3h6yhwVl395k0Mtx8v6CGhq5r4KQdAoPbADU974Mauz1b6ViHAJ74O0IVE5vyy7tD3OpkQxL/vMDQ==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.7.tgz",
       "integrity": "sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.7.tgz",
       "integrity": "sha512-cTZWTnCXLABOuvWiv6nQQM0hP6ZWEkzdgDvztgHI/+u/MvtzJBN5lBQ2lue/9sSFYLMqzqff5EHKlFtrJCA9dQ==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.7.tgz",
       "integrity": "sha512-hoeTJFBiE/IJP30Be7djWF8Q5KVgkbDtjySmvYLg9P94bHg9TJPSQoC72tXx/oXOgXvElDe/GMybru0UxhKx4g==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.7.tgz",
       "integrity": "sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.7.tgz",
       "integrity": "sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.7.tgz",
       "integrity": "sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.7.tgz",
       "integrity": "sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.7.tgz",
       "integrity": "sha512-Xm0TfvcmmspvQg1s4+USL3x8D+YPAfX2JHygvxAnCJ0EHun8cm2zvfNBcsTlnwYb0ybFWXXY129aq1wgFC9TpQ==",
+      "dev": true,
       "optional": true
     },
     "@swc/core-win32-x64-msvc": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.7.tgz",
       "integrity": "sha512-tp43WfJLCsKLQKBmjmY/0vv1slVywR5Q4qKjF5OIY8QijaEW7/8VwPyUyVoJZEnDgv9jKtUTG5PzqtIYPZGnyg==",
+      "dev": true,
       "optional": true
     },
     "@swc/counter": {
@@ -31278,6 +31199,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
       "integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
+      "dev": true,
       "requires": {
         "@swc/counter": "^0.1.3"
       }
@@ -32566,8 +32488,7 @@
     "@webpack-cli/configtest": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-      "requires": {}
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg=="
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -32580,8 +32501,7 @@
     "@webpack-cli/serve": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-      "requires": {}
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -32670,15 +32590,13 @@
     "acorn-import-assertions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "requires": {}
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.3.1",
@@ -32740,8 +32658,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -34237,8 +34154,7 @@
     "css-prefers-color-scheme": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-9.0.1.tgz",
-      "integrity": "sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g==",
-      "requires": {}
+      "integrity": "sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g=="
     },
     "css-select": {
       "version": "5.1.0",
@@ -35024,8 +34940,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -36025,8 +35940,7 @@
     "graphql-http": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.21.0.tgz",
-      "integrity": "sha512-yrItPfHj5WeT4n7iusbVin+vGSQjXFAX6U/GnYytdCJRXVad1TWGtYFDZ2ROjCKpXQzIwvfbiWCEwfuXgR3B6A==",
-      "requires": {}
+      "integrity": "sha512-yrItPfHj5WeT4n7iusbVin+vGSQjXFAX6U/GnYytdCJRXVad1TWGtYFDZ2ROjCKpXQzIwvfbiWCEwfuXgR3B6A=="
     },
     "graphql-playground-html": {
       "version": "1.6.30",
@@ -36063,8 +35977,7 @@
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
-      "requires": {}
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
     },
     "gunzip-maybe": {
       "version": "1.4.2",
@@ -36421,8 +36334,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -36966,12 +36878,6 @@
         }
       }
     },
-    "isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "peer": true
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -37204,19 +37110,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "babel-plugin-macros": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-          "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "cosmiconfig": "^7.0.0",
-            "resolve": "^1.19.0"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -37242,27 +37135,11 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "cosmiconfig": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-          "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.2.1",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.10.0"
-          }
-        },
         "dedent": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
           "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
@@ -37764,8 +37641,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -38669,15 +38545,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.13.1.tgz",
       "integrity": "sha512-jaqRYzVEfBKbX4FwYpd/g+MyOjRaraAel0iQsTrwvx3hyN0bswUZuzb6H6nGlFSjcdrc77wKpyKwoWj4aUd+Bw=="
-    },
-    "lib0": {
-      "version": "0.2.94",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.94.tgz",
-      "integrity": "sha512-hZ3p54jL4Wpu7IOg26uC7dnEWiMyNlUrb9KoG7+xYs45WkQwpVvKFndVq2+pqLYKe1u8Fp3+zAfZHVvTK34PvQ==",
-      "peer": true,
-      "requires": {
-        "isomorphic.js": "^0.2.4"
-      }
     },
     "lines-and-columns": {
       "version": "2.0.4",
@@ -41070,14 +40937,12 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "requires": {}
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
     },
     "postcss-gap-properties": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-5.0.1.tgz",
-      "integrity": "sha512-k2z9Cnngc24c0KF4MtMuDdToROYqGMMUQGcE6V0odwjHyOHtaDBlLeRBV70y9/vF7KIbShrTRZ70JjsI1BZyWw==",
-      "requires": {}
+      "integrity": "sha512-k2z9Cnngc24c0KF4MtMuDdToROYqGMMUQGcE6V0odwjHyOHtaDBlLeRBV70y9/vF7KIbShrTRZ70JjsI1BZyWw=="
     },
     "postcss-image-set-function": {
       "version": "6.0.2",
@@ -41090,8 +40955,7 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "requires": {}
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
     },
     "postcss-lab-function": {
       "version": "6.0.8",
@@ -41160,8 +41024,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "requires": {}
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -41201,8 +41064,7 @@
     "postcss-opacity-percentage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-2.0.0.tgz",
-      "integrity": "sha512-lyDrCOtntq5Y1JZpBFzIWm2wG9kbEdujpNt4NLannF+J9c8CgFIzPa80YQfdza+Y+yFfzbYj/rfoOsYsooUWTQ==",
-      "requires": {}
+      "integrity": "sha512-lyDrCOtntq5Y1JZpBFzIWm2wG9kbEdujpNt4NLannF+J9c8CgFIzPa80YQfdza+Y+yFfzbYj/rfoOsYsooUWTQ=="
     },
     "postcss-overflow-shorthand": {
       "version": "5.0.1",
@@ -41215,8 +41077,7 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "requires": {}
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
     },
     "postcss-place": {
       "version": "9.0.1",
@@ -41300,8 +41161,7 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "requires": {}
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
     },
     "postcss-selector-not": {
       "version": "7.0.1",
@@ -41769,8 +41629,7 @@
     "react-image-crop": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.1.8.tgz",
-      "integrity": "sha512-4rb8XtXNx7ZaOZarKKnckgz4xLMvds/YrU6mpJfGhGAsy2Mg4mIw1x+DCCGngVGq2soTBVVOxx2s/C6mTX9+pA==",
-      "requires": {}
+      "integrity": "sha512-4rb8XtXNx7ZaOZarKKnckgz4xLMvds/YrU6mpJfGhGAsy2Mg4mIw1x+DCCGngVGq2soTBVVOxx2s/C6mTX9+pA=="
     },
     "react-is": {
       "version": "18.2.0",
@@ -41781,8 +41640,7 @@
     "react-onclickoutside": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
-      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
-      "requires": {}
+      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A=="
     },
     "react-popper": {
       "version": "2.3.0",
@@ -41846,8 +41704,7 @@
     "react-router-navigation-prompt": {
       "version": "1.9.6",
       "resolved": "https://registry.npmjs.org/react-router-navigation-prompt/-/react-router-navigation-prompt-1.9.6.tgz",
-      "integrity": "sha512-l0sAtbroHK8i1/Eyy29XcrMpBEt0R08BaScgMUt8r5vWWbLz7G0ChOikayTCQm7QgDFsHw8gVnxDJb7TBZCAKg==",
-      "requires": {}
+      "integrity": "sha512-l0sAtbroHK8i1/Eyy29XcrMpBEt0R08BaScgMUt8r5vWWbLz7G0ChOikayTCQm7QgDFsHw8gVnxDJb7TBZCAKg=="
     },
     "react-select": {
       "version": "5.7.4",
@@ -41868,8 +41725,7 @@
     "react-side-effect": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-      "requires": {}
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw=="
     },
     "react-toastify": {
       "version": "8.2.0",
@@ -43062,14 +42918,12 @@
     "swc-loader": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.3.tgz",
-      "integrity": "sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==",
-      "requires": {}
+      "integrity": "sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A=="
     },
     "swc-minify-webpack-plugin": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/swc-minify-webpack-plugin/-/swc-minify-webpack-plugin-2.1.1.tgz",
-      "integrity": "sha512-/9ud/libNWUC5p71vXWhW/O2Nc0essW8D9pY4P4ol0ceM8OcFbNr41R9YFqTkmktqUL2t0WwXau+FkR4T1+PJA==",
-      "requires": {}
+      "integrity": "sha512-/9ud/libNWUC5p71vXWhW/O2Nc0essW8D9pY4P4ol0ceM8OcFbNr41R9YFqTkmktqUL2t0WwXau+FkR4T1+PJA=="
     },
     "tabbable": {
       "version": "5.3.3",
@@ -43384,14 +43238,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-essentials": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
-      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
-      "requires": {}
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ=="
     },
     "ts-jest": {
       "version": "29.2.3",
@@ -43547,7 +43399,8 @@
     "typescript": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.17.4",
@@ -43657,14 +43510,12 @@
     "use-context-selector": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.1.tgz",
-      "integrity": "sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA==",
-      "requires": {}
+      "integrity": "sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA=="
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "requires": {}
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -44278,8 +44129,7 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "requires": {}
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
     },
     "xss": {
       "version": "1.0.14",
@@ -44349,15 +44199,6 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"
-      }
-    },
-    "yjs": {
-      "version": "13.6.18",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
-      "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
-      "peer": true,
-      "requires": {
-        "lib0": "^0.2.86"
       }
     },
     "yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7503,7 +7503,6 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz",
       "integrity": "sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.2",
@@ -7544,7 +7543,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7560,7 +7558,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7576,7 +7573,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7592,7 +7588,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7608,7 +7603,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7624,7 +7618,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7640,7 +7633,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7656,7 +7648,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7672,7 +7663,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7688,7 +7678,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7747,7 +7736,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
       "integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
-      "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
@@ -15473,6 +15461,16 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -15785,6 +15783,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -15818,6 +15833,24 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/jest-circus/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.5.1",
@@ -17705,6 +17738,27 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.13.1.tgz",
       "integrity": "sha512-jaqRYzVEfBKbX4FwYpd/g+MyOjRaraAel0iQsTrwvx3hyN0bswUZuzb6H6nGlFSjcdrc77wKpyKwoWj4aUd+Bw=="
+    },
+    "node_modules/lib0": {
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "2.0.4",
@@ -24628,7 +24682,6 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -25775,6 +25828,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/yjs": {
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.98"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -26762,7 +26832,8 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -28162,7 +28233,8 @@
     "@csstools/cascade-layer-name-parser": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-1.0.6.tgz",
-      "integrity": "sha512-HkxRNs6ZIV0VjLFw6k5G8K35vd9r+O8B1Vr+QVD8M5Y44eQxyHtc42BdF74FQatXACPnitOR1+sRx2oWdnKTQw=="
+      "integrity": "sha512-HkxRNs6ZIV0VjLFw6k5G8K35vd9r+O8B1Vr+QVD8M5Y44eQxyHtc42BdF74FQatXACPnitOR1+sRx2oWdnKTQw==",
+      "requires": {}
     },
     "@csstools/color-helpers": {
       "version": "4.0.0",
@@ -28172,7 +28244,8 @@
     "@csstools/css-calc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-1.1.5.tgz",
-      "integrity": "sha512-UhI5oSRAUtTHY3MyGahqn0ZzQOHVoPpfvUcOmYipAZ1rILAvCBoyiLSsa/clv1Xxct0SMKIq93KO5Bfl1cb6tQ=="
+      "integrity": "sha512-UhI5oSRAUtTHY3MyGahqn0ZzQOHVoPpfvUcOmYipAZ1rILAvCBoyiLSsa/clv1Xxct0SMKIq93KO5Bfl1cb6tQ==",
+      "requires": {}
     },
     "@csstools/css-color-parser": {
       "version": "1.5.0",
@@ -28186,7 +28259,8 @@
     "@csstools/css-parser-algorithms": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.4.0.tgz",
-      "integrity": "sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg=="
+      "integrity": "sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg==",
+      "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "2.2.2",
@@ -28196,7 +28270,8 @@
     "@csstools/media-query-list-parser": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.6.tgz",
-      "integrity": "sha512-R6AKl9vaU0It7D7TR2lQn0pre5aQfdeqHRePlaRCY8rHL3l9eVlNRpsEVDKFi/zAjzv68CxH2M5kqbhPFPKjvw=="
+      "integrity": "sha512-R6AKl9vaU0It7D7TR2lQn0pre5aQfdeqHRePlaRCY8rHL3l9eVlNRpsEVDKFi/zAjzv68CxH2M5kqbhPFPKjvw==",
+      "requires": {}
     },
     "@csstools/postcss-cascade-layers": {
       "version": "4.0.2",
@@ -28299,7 +28374,8 @@
     "@csstools/postcss-logical-float-and-clear": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-float-and-clear/-/postcss-logical-float-and-clear-2.0.1.tgz",
-      "integrity": "sha512-SsrWUNaXKr+e/Uo4R/uIsqJYt3DaggIh/jyZdhy/q8fECoJSKsSMr7nObSLdvoULB69Zb6Bs+sefEIoMG/YfOA=="
+      "integrity": "sha512-SsrWUNaXKr+e/Uo4R/uIsqJYt3DaggIh/jyZdhy/q8fECoJSKsSMr7nObSLdvoULB69Zb6Bs+sefEIoMG/YfOA==",
+      "requires": {}
     },
     "@csstools/postcss-logical-resize": {
       "version": "2.0.1",
@@ -28424,12 +28500,14 @@
     "@csstools/postcss-unset-value": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-3.0.1.tgz",
-      "integrity": "sha512-dbDnZ2ja2U8mbPP0Hvmt2RMEGBiF1H7oY6HYSpjteXJGihYwgxgTr6KRbbJ/V6c+4wd51M+9980qG4gKVn5ttg=="
+      "integrity": "sha512-dbDnZ2ja2U8mbPP0Hvmt2RMEGBiF1H7oY6HYSpjteXJGihYwgxgTr6KRbbJ/V6c+4wd51M+9980qG4gKVn5ttg==",
+      "requires": {}
     },
     "@csstools/selector-specificity": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.1.tgz",
-      "integrity": "sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww=="
+      "integrity": "sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww==",
+      "requires": {}
     },
     "@cypress/request": {
       "version": "3.0.1",
@@ -28697,7 +28775,8 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw=="
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.2.1",
@@ -28787,12 +28866,14 @@
     "@faceless-ui/scroll-info": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@faceless-ui/scroll-info/-/scroll-info-1.3.0.tgz",
-      "integrity": "sha512-X+doJMzQqyVGpwV/YgXUAalNWepP2W8ThgZspKZLFG43zTYLVTU17BYCjjY+ggKuA3b0W3JyXZ2M8f247AdmHw=="
+      "integrity": "sha512-X+doJMzQqyVGpwV/YgXUAalNWepP2W8ThgZspKZLFG43zTYLVTU17BYCjjY+ggKuA3b0W3JyXZ2M8f247AdmHw==",
+      "requires": {}
     },
     "@faceless-ui/window-info": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@faceless-ui/window-info/-/window-info-2.1.1.tgz",
-      "integrity": "sha512-gMAgda7beR4CNpBIXjgRVn97ek0LG3PAj9lxmoYdg574IEzLFZAh3eAYtTaS2XLKgb4+IHhsuBzlGmHbeOo2Aw=="
+      "integrity": "sha512-gMAgda7beR4CNpBIXjgRVn97ek0LG3PAj9lxmoYdg574IEzLFZAh3eAYtTaS2XLKgb4+IHhsuBzlGmHbeOo2Aw==",
+      "requires": {}
     },
     "@floating-ui/core": {
       "version": "1.5.2",
@@ -29489,7 +29570,8 @@
     "@lexical/dragon": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.13.1.tgz",
-      "integrity": "sha512-aNlqfif4//jW7gOxbBgdrbDovU6m3EwQrUw+Y/vqRkY+sWmloyAUeNwCPH1QP3Q5cvfolzOeN5igfBljsFr+1g=="
+      "integrity": "sha512-aNlqfif4//jW7gOxbBgdrbDovU6m3EwQrUw+Y/vqRkY+sWmloyAUeNwCPH1QP3Q5cvfolzOeN5igfBljsFr+1g==",
+      "requires": {}
     },
     "@lexical/hashtag": {
       "version": "0.13.1",
@@ -29502,7 +29584,8 @@
     "@lexical/headless": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/headless/-/headless-0.13.1.tgz",
-      "integrity": "sha512-W2mLUuWPrsyf2n73NWM8nKiBI11lEpVVzKE0OzMsjTskv5+AAMaeu1wQ7M1508vKdCcUZwA6AOh3To/hstLEpw=="
+      "integrity": "sha512-W2mLUuWPrsyf2n73NWM8nKiBI11lEpVVzKE0OzMsjTskv5+AAMaeu1wQ7M1508vKdCcUZwA6AOh3To/hstLEpw==",
+      "requires": {}
     },
     "@lexical/history": {
       "version": "0.13.1",
@@ -29561,17 +29644,20 @@
     "@lexical/offset": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.13.1.tgz",
-      "integrity": "sha512-j/RZcztJ7dyTrfA2+C3yXDzWDXV+XmMpD5BYeQCEApaHvlo20PHt1BISk7RcrnQW8PdzGvpKblRWf//c08LS9w=="
+      "integrity": "sha512-j/RZcztJ7dyTrfA2+C3yXDzWDXV+XmMpD5BYeQCEApaHvlo20PHt1BISk7RcrnQW8PdzGvpKblRWf//c08LS9w==",
+      "requires": {}
     },
     "@lexical/overflow": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.13.1.tgz",
-      "integrity": "sha512-Uw34j+qG2UJRCIR+bykfFMduFk7Pc4r/kNt8N1rjxGuGXAsreTVch1iOhu7Ev6tJgkURsduKuaJCAi7iHnKl7g=="
+      "integrity": "sha512-Uw34j+qG2UJRCIR+bykfFMduFk7Pc4r/kNt8N1rjxGuGXAsreTVch1iOhu7Ev6tJgkURsduKuaJCAi7iHnKl7g==",
+      "requires": {}
     },
     "@lexical/plain-text": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.13.1.tgz",
-      "integrity": "sha512-4j5KAsMKUvJ8LhVDSS4zczbYXzdfmgYSAVhmqpSnJtud425Nk0TAfpUBLFoivxZB7KMoT1LGWQZvd47IvJPvtA=="
+      "integrity": "sha512-4j5KAsMKUvJ8LhVDSS4zczbYXzdfmgYSAVhmqpSnJtud425Nk0TAfpUBLFoivxZB7KMoT1LGWQZvd47IvJPvtA==",
+      "requires": {}
     },
     "@lexical/react": {
       "version": "0.13.1",
@@ -29611,12 +29697,14 @@
     "@lexical/rich-text": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.13.1.tgz",
-      "integrity": "sha512-HliB9Ync06mv9DBg/5j0lIsTJp+exLHlaLJe+n8Zq1QNTzZzu2LsIT/Crquk50In7K/cjtlaQ/d5RB0LkjMHYg=="
+      "integrity": "sha512-HliB9Ync06mv9DBg/5j0lIsTJp+exLHlaLJe+n8Zq1QNTzZzu2LsIT/Crquk50In7K/cjtlaQ/d5RB0LkjMHYg==",
+      "requires": {}
     },
     "@lexical/selection": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.13.1.tgz",
-      "integrity": "sha512-Kt9eSwjxPznj7yzIYipu9yYEgmRJhHiq3DNxHRxInYcZJWWNNHum2xKyxwwcN8QYBBzgfPegfM/geqQEJSV1lQ=="
+      "integrity": "sha512-Kt9eSwjxPznj7yzIYipu9yYEgmRJhHiq3DNxHRxInYcZJWWNNHum2xKyxwwcN8QYBBzgfPegfM/geqQEJSV1lQ==",
+      "requires": {}
     },
     "@lexical/table": {
       "version": "0.13.1",
@@ -29629,7 +29717,8 @@
     "@lexical/text": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.13.1.tgz",
-      "integrity": "sha512-NYy3TZKt3qzReDwN2Rr5RxyFlg84JjXP2JQGMrXSSN7wYe73ysQIU6PqdVrz4iZkP+w34F3pl55dJ24ei3An9w=="
+      "integrity": "sha512-NYy3TZKt3qzReDwN2Rr5RxyFlg84JjXP2JQGMrXSSN7wYe73ysQIU6PqdVrz4iZkP+w34F3pl55dJ24ei3An9w==",
+      "requires": {}
     },
     "@lexical/utils": {
       "version": "0.13.1",
@@ -31033,7 +31122,8 @@
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@swc-node/core/-/core-1.13.3.tgz",
       "integrity": "sha512-OGsvXIid2Go21kiNqeTIn79jcaX4l0G93X2rAnas4LFoDyA9wAwVK7xZdm+QsKoMn5Mus2yFLCc4OtX2dD/PWA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@swc-node/register": {
       "version": "1.9.2",
@@ -31075,7 +31165,6 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz",
       "integrity": "sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==",
-      "dev": true,
       "requires": {
         "@swc/core-darwin-arm64": "1.5.7",
         "@swc/core-darwin-x64": "1.5.7",
@@ -31095,70 +31184,60 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.7.tgz",
       "integrity": "sha512-bZLVHPTpH3h6yhwVl395k0Mtx8v6CGhq5r4KQdAoPbADU974Mauz1b6ViHAJ74O0IVE5vyy7tD3OpkQxL/vMDQ==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.7.tgz",
       "integrity": "sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.7.tgz",
       "integrity": "sha512-cTZWTnCXLABOuvWiv6nQQM0hP6ZWEkzdgDvztgHI/+u/MvtzJBN5lBQ2lue/9sSFYLMqzqff5EHKlFtrJCA9dQ==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.7.tgz",
       "integrity": "sha512-hoeTJFBiE/IJP30Be7djWF8Q5KVgkbDtjySmvYLg9P94bHg9TJPSQoC72tXx/oXOgXvElDe/GMybru0UxhKx4g==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.7.tgz",
       "integrity": "sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.7.tgz",
       "integrity": "sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.7.tgz",
       "integrity": "sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.7.tgz",
       "integrity": "sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.7.tgz",
       "integrity": "sha512-Xm0TfvcmmspvQg1s4+USL3x8D+YPAfX2JHygvxAnCJ0EHun8cm2zvfNBcsTlnwYb0ybFWXXY129aq1wgFC9TpQ==",
-      "dev": true,
       "optional": true
     },
     "@swc/core-win32-x64-msvc": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.7.tgz",
       "integrity": "sha512-tp43WfJLCsKLQKBmjmY/0vv1slVywR5Q4qKjF5OIY8QijaEW7/8VwPyUyVoJZEnDgv9jKtUTG5PzqtIYPZGnyg==",
-      "dev": true,
       "optional": true
     },
     "@swc/counter": {
@@ -31199,7 +31278,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
       "integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
-      "dev": true,
       "requires": {
         "@swc/counter": "^0.1.3"
       }
@@ -32488,7 +32566,8 @@
     "@webpack-cli/configtest": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg=="
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -32501,7 +32580,8 @@
     "@webpack-cli/serve": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q=="
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -32590,13 +32670,15 @@
     "acorn-import-assertions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA=="
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.3.1",
@@ -32658,7 +32740,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -34154,7 +34237,8 @@
     "css-prefers-color-scheme": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-9.0.1.tgz",
-      "integrity": "sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g=="
+      "integrity": "sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g==",
+      "requires": {}
     },
     "css-select": {
       "version": "5.1.0",
@@ -34940,7 +35024,8 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -35940,7 +36025,8 @@
     "graphql-http": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.21.0.tgz",
-      "integrity": "sha512-yrItPfHj5WeT4n7iusbVin+vGSQjXFAX6U/GnYytdCJRXVad1TWGtYFDZ2ROjCKpXQzIwvfbiWCEwfuXgR3B6A=="
+      "integrity": "sha512-yrItPfHj5WeT4n7iusbVin+vGSQjXFAX6U/GnYytdCJRXVad1TWGtYFDZ2ROjCKpXQzIwvfbiWCEwfuXgR3B6A==",
+      "requires": {}
     },
     "graphql-playground-html": {
       "version": "1.6.30",
@@ -35977,7 +36063,8 @@
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
+      "requires": {}
     },
     "gunzip-maybe": {
       "version": "1.4.2",
@@ -36334,7 +36421,8 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "requires": {}
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -36878,6 +36966,12 @@
         }
       }
     },
+    "isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "peer": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -37110,6 +37204,19 @@
             "color-convert": "^2.0.1"
           }
         },
+        "babel-plugin-macros": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+          "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "cosmiconfig": "^7.0.0",
+            "resolve": "^1.19.0"
+          }
+        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -37135,11 +37242,27 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "cosmiconfig": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+          "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
         "dedent": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
           "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "has-flag": {
           "version": "4.0.0",
@@ -37641,7 +37764,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -38545,6 +38669,15 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.13.1.tgz",
       "integrity": "sha512-jaqRYzVEfBKbX4FwYpd/g+MyOjRaraAel0iQsTrwvx3hyN0bswUZuzb6H6nGlFSjcdrc77wKpyKwoWj4aUd+Bw=="
+    },
+    "lib0": {
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
+      "peer": true,
+      "requires": {
+        "isomorphic.js": "^0.2.4"
+      }
     },
     "lines-and-columns": {
       "version": "2.0.4",
@@ -40937,12 +41070,14 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-5.0.1.tgz",
-      "integrity": "sha512-k2z9Cnngc24c0KF4MtMuDdToROYqGMMUQGcE6V0odwjHyOHtaDBlLeRBV70y9/vF7KIbShrTRZ70JjsI1BZyWw=="
+      "integrity": "sha512-k2z9Cnngc24c0KF4MtMuDdToROYqGMMUQGcE6V0odwjHyOHtaDBlLeRBV70y9/vF7KIbShrTRZ70JjsI1BZyWw==",
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "6.0.2",
@@ -40955,7 +41090,8 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+      "requires": {}
     },
     "postcss-lab-function": {
       "version": "6.0.8",
@@ -41024,7 +41160,8 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -41064,7 +41201,8 @@
     "postcss-opacity-percentage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-2.0.0.tgz",
-      "integrity": "sha512-lyDrCOtntq5Y1JZpBFzIWm2wG9kbEdujpNt4NLannF+J9c8CgFIzPa80YQfdza+Y+yFfzbYj/rfoOsYsooUWTQ=="
+      "integrity": "sha512-lyDrCOtntq5Y1JZpBFzIWm2wG9kbEdujpNt4NLannF+J9c8CgFIzPa80YQfdza+Y+yFfzbYj/rfoOsYsooUWTQ==",
+      "requires": {}
     },
     "postcss-overflow-shorthand": {
       "version": "5.0.1",
@@ -41077,7 +41215,8 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+      "requires": {}
     },
     "postcss-place": {
       "version": "9.0.1",
@@ -41161,7 +41300,8 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "7.0.1",
@@ -41629,7 +41769,8 @@
     "react-image-crop": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.1.8.tgz",
-      "integrity": "sha512-4rb8XtXNx7ZaOZarKKnckgz4xLMvds/YrU6mpJfGhGAsy2Mg4mIw1x+DCCGngVGq2soTBVVOxx2s/C6mTX9+pA=="
+      "integrity": "sha512-4rb8XtXNx7ZaOZarKKnckgz4xLMvds/YrU6mpJfGhGAsy2Mg4mIw1x+DCCGngVGq2soTBVVOxx2s/C6mTX9+pA==",
+      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",
@@ -41640,7 +41781,8 @@
     "react-onclickoutside": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
-      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A=="
+      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
+      "requires": {}
     },
     "react-popper": {
       "version": "2.3.0",
@@ -41704,7 +41846,8 @@
     "react-router-navigation-prompt": {
       "version": "1.9.6",
       "resolved": "https://registry.npmjs.org/react-router-navigation-prompt/-/react-router-navigation-prompt-1.9.6.tgz",
-      "integrity": "sha512-l0sAtbroHK8i1/Eyy29XcrMpBEt0R08BaScgMUt8r5vWWbLz7G0ChOikayTCQm7QgDFsHw8gVnxDJb7TBZCAKg=="
+      "integrity": "sha512-l0sAtbroHK8i1/Eyy29XcrMpBEt0R08BaScgMUt8r5vWWbLz7G0ChOikayTCQm7QgDFsHw8gVnxDJb7TBZCAKg==",
+      "requires": {}
     },
     "react-select": {
       "version": "5.7.4",
@@ -41725,7 +41868,8 @@
     "react-side-effect": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw=="
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "requires": {}
     },
     "react-toastify": {
       "version": "8.2.0",
@@ -42918,12 +43062,14 @@
     "swc-loader": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.3.tgz",
-      "integrity": "sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A=="
+      "integrity": "sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==",
+      "requires": {}
     },
     "swc-minify-webpack-plugin": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/swc-minify-webpack-plugin/-/swc-minify-webpack-plugin-2.1.1.tgz",
-      "integrity": "sha512-/9ud/libNWUC5p71vXWhW/O2Nc0essW8D9pY4P4ol0ceM8OcFbNr41R9YFqTkmktqUL2t0WwXau+FkR4T1+PJA=="
+      "integrity": "sha512-/9ud/libNWUC5p71vXWhW/O2Nc0essW8D9pY4P4ol0ceM8OcFbNr41R9YFqTkmktqUL2t0WwXau+FkR4T1+PJA==",
+      "requires": {}
     },
     "tabbable": {
       "version": "5.3.3",
@@ -43238,12 +43384,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-essentials": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
-      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ=="
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "requires": {}
     },
     "ts-jest": {
       "version": "29.2.3",
@@ -43399,8 +43547,7 @@
     "typescript": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
     },
     "uglify-js": {
       "version": "3.17.4",
@@ -43510,12 +43657,14 @@
     "use-context-selector": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.1.tgz",
-      "integrity": "sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA=="
+      "integrity": "sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -44129,7 +44278,8 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
     },
     "xss": {
       "version": "1.0.14",
@@ -44199,6 +44349,15 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"
+      }
+    },
+    "yjs": {
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
+      "peer": true,
+      "requires": {
+        "lib0": "^0.2.98"
       }
     },
     "yn": {

--- a/plugin/docs/crowdin.md
+++ b/plugin/docs/crowdin.md
@@ -82,6 +82,11 @@ A `crowdin-article-directories` document represents a folder created on Crowdin 
 
 `crowdin-article-directories` can also have a one-to-one relationship with each other through the `parent` field. These directories are created within parent diretories to contain translations for blocks within a Lexical `richText` field.
 
+`crowdin-article-directories` documents created for Lexical blocks have the following differences:
+
+- The `name` field is set to the Lexical field name in dot notation prefixed with `pluginOptions.lexicalBlockFolderPrefix`. Normal `crowdin-article-directories` documents set the `name` field as the `id` of the corresponding document.
+- The `parent` field is defined. Normal `crowdin-article-directories` documents have an `parent` of `undefined`.
+
 ### `crowdin-files`
 
 Each entry in the `crowdin-files` collection has a one-to-one relationship with an entry in the `crowdin-article-directories` collection.

--- a/plugin/docs/crowdin.md
+++ b/plugin/docs/crowdin.md
@@ -1,26 +1,98 @@
 # Crowdin collections
 
+Rather than uploading a document json object directly into Crowdin, this plugin transforms a Payload document into multiple `html` and `json` files that contain localized field values only. This greatly enhances the localization experience in Crowdin.
+
+Following are details of the transformation process, how documents are modified and how the plugin keeps in sync with Crowdin.
+
+## Crowdin folder structure
+
 By default, files are uploaded to Crowdin using the following folder/file structure.
 
 ```
-"Payload CMS" > [collectionSlug] > [articleSlug] > [fieldSlug]
+[collectionSlug] > [articleSlug] > [fieldSlug]
+```
+
+Files can be uploaded to a specific directory by setting the `directoryId` option.
+
+```
+"My Directory" > [collectionSlug] > [articleSlug] > [fieldSlug]
 ```
 
 - Rich text fields are stored as HTML files.
-- All other fields are stored as JSON files.
+- All other fields are compiled into JSON files.
 
-For each entry in a collection that contains localized fields, an additonal field is added: `crowdinArticleDirectory`. This is a one-to-one relationship with an article created in the `crowdin-article-directories` collection.
+## Rich text fields
 
-When a localized field is changed, a file is created/updated in the `crowdin-files` collection for that field. Details of the file are stored in Payload so that this file can be updated or deleted in the future. Each entry in the `crowdin-files` collection has a one-to-one relationship with the appropriate entry in the `crowdin-article-directories` collection.
+For ease-of-editing in Crowdin, the underlying editor object is converted to HTML. When translated HTML is synced back into Payload, it is converted back to an apporpriate object.
 
-- `richText` fields have their own Crowdin file. e.g. `content.html`. For ease-of-editing in Crowdin, Slate JSON is converted to HTML. When translated HTML is synced back into Payload, it is converted back to Slate JSON.
-- All other fields are compiled into a single `fields.json` file for ease-of-editing in Crowdin.
+Each `richText` field has its own Crowdin file. e.g. `content.html`.
+
+The object conversion depends on the rich text editor used in that field. See [Rich Text Field | Payload](https://payloadcms.com/docs/fields/rich-text).
+
+### Blocks
+
+Translation of blocks within Lexical editor fields is supported.
+
+For each Lexical field with blocks, blocks are extracted and 'treated as an imaginary localized document' in order to re-use as much plugin logic as possible:
+
+- a new `crowdin-article-directories` document is created with a parent of the localized document, or a parent Lexical field.
+- blocks are compiled into an imaginary [blocks field](https://payloadcms.com/docs/fields/blocks) with a field name of `blocks`.
+
+```
+const fields: Field[] = [
+  {
+    name: 'blocks',
+    type: 'blocks',
+    blocks: blockConfig.blocks,
+  }
+]
+```
+
+...where `blockConfig` is extracted from the Lexical field editor config.
+
+#### Blocks are not localized
+
+One key difference between regular localized documents and the imaginary localized documents created for Lexical field blocks is that there is no way to identify which fields are localized and which fields are not.
+
+Cureently, this approach only supports non-localized fields. This is because these blocks live within a Lexical field that may or may not localized, and therefore it doesn't make sense for blocks within a localized field to also be localized - there will be an entirely different field with different block instances in different locales.
+
+## Text fields
+
+All other fields are compiled into a single `fields.json` file for ease-of-editing in Crowdin.
+
+## How the database is modified
+
+Three new collections are created.
+
+- `crowdin-collection-directories`
+- `crowdin-article-directories`
+- `crowdin-files`
+
+For each document in a collection that contains localized fields, an additonal field is added: `crowdinArticleDirectory`. This is a one-to-one relationship with an article created in the `crowdin-article-directories` collection.
+
+### `crowdin-collection-directories`
 
 Each entry in the `crowdin-article-directories` collection has a one-to-one relationship with an entry in the `crowdin-collection-directories` collection.
 
-One-to-one relationships help preserve database integrity and simplify the operations needed to perform CRUD operations on all related entries.
+### `crowdin-article-directories`
 
-All of the collections created by this plugin are designed to emulate the structure of API calls needed to communicate with crowdin. Each directory/file is created in a single API operation on Crowdin, and it is necessary to keep track of the details of each directory and file for future interactions.
+A `crowdin-article-directories` document represents a folder created on Crowdin containing files for a given Payload document.
+
+#### `crowdin-article-directories` children
+
+`crowdin-article-directories` can also have a one-to-one relationship with each other through the `parent` field. These directories are created within parent diretories to contain translations for blocks within a Lexical `richText` field.
+
+### `crowdin-files`
+
+Each entry in the `crowdin-files` collection has a one-to-one relationship with an entry in the `crowdin-article-directories` collection.
+
+When a localized field is changed, a file is created/updated in the `crowdin-files` collection for that field. Details of the file are stored in Payload so that this file can be updated or deleted in the future. Each entry in the `crowdin-files` collection has a one-to-one relationship with the appropriate entry in the `crowdin-article-directories` collection.
+
+#### `crowdin-files` children
+
+- A new `crowdin-article-directories` document is created for each block and is stored within the parent folder on Crowdin. See [`crowdin-article-directories` children](#crowdin-article-directories-children).
+- The `documentId` of the `crowdin-files` document is a string containing dot notation pointing to the `richText` field.
+
 
 ## Payload collection slug change
 

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -3,7 +3,6 @@ import { CrowdinArticleDirectory, CrowdinCollectionDirectory, CrowdinFile } from
 import { payloadCrowdinSyncTranslationsApi } from "./payload-crowdin-sync/translations";
 import { PluginOptions, isCollectionOrGlobalConfigObject, isCollectionOrGlobalConfigSlug, isCrowdinArticleDirectory } from "../types";
 import { getRelationshipId } from "../utilities/payload";
-import { PaginatedDocs } from "payload/database";
 
 /**
  * get Crowdin Article Directory for a given documentId

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -86,7 +86,6 @@ export async function getFileByParent(
     },
   });
 
-  //console.log('name', name, 'crowdinArticleDirectory', crowdinArticleDirectory, 'crowdin-files', result.docs)
   return result.docs[0];
 }
 
@@ -94,6 +93,33 @@ export async function getFiles(
   crowdinArticleDirectoryId: string,
   payload: Payload
 ): Promise<any> {
+  const result = await payload.find({
+    collection: "crowdin-files",
+    limit: 10000,
+    where: {
+      crowdinArticleDirectory: {
+        equals: crowdinArticleDirectoryId,
+      },
+    },
+  });
+  return result.docs;
+}
+
+export async function getFilesByParent(
+  parentCrowdinArticleDirectoryId: string,
+  payload: Payload
+): Promise<any> {
+  const dirResult = await payload.find({
+    collection: "crowdin-article-directories",
+    where: {
+      parent: {
+        equals: parentCrowdinArticleDirectoryId,
+      },
+    },
+  });
+  const crowdinArticleDirectory = dirResult.docs[0]
+  const crowdinArticleDirectoryId = getRelationshipId(crowdinArticleDirectory as any)
+
   const result = await payload.find({
     collection: "crowdin-files",
     limit: 10000,

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -2,6 +2,8 @@ import { Payload } from "payload";
 import { CrowdinArticleDirectory, CrowdinCollectionDirectory, CrowdinFile } from "../payload-types";
 import { payloadCrowdinSyncTranslationsApi } from "./payload-crowdin-sync/translations";
 import { PluginOptions, isCollectionOrGlobalConfigObject, isCollectionOrGlobalConfigSlug, isCrowdinArticleDirectory } from "../types";
+import { getRelationshipId } from "../utilities/payload";
+import { PaginatedDocs } from "payload/database";
 
 /**
  * get Crowdin Article Directory for a given documentId
@@ -55,6 +57,36 @@ export async function getFile(
       },
     },
   });
+  return result.docs[0];
+}
+
+export async function getFileByParent(
+  name: string,
+  parentCrowdinArticleDirectoryId: string,
+  payload: Payload
+): Promise<any> {
+  const dirResult = await payload.find({
+    collection: "crowdin-article-directories",
+    where: {
+      parent: {
+        equals: parentCrowdinArticleDirectoryId,
+      },
+    },
+  });
+  const crowdinArticleDirectory = dirResult.docs[0]
+  const crowdinArticleDirectoryId = getRelationshipId(crowdinArticleDirectory as any)
+
+  const result = await payload.find({
+    collection: "crowdin-files",
+    where: {
+      field: { equals: name },
+      crowdinArticleDirectory: {
+        equals: crowdinArticleDirectoryId,
+      },
+    },
+  });
+
+  //console.log('name', name, 'crowdinArticleDirectory', crowdinArticleDirectory, 'crowdin-files', result.docs)
   return result.docs[0];
 }
 

--- a/plugin/src/lib/api/payload-crowdin-sync/translations.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/translations.ts
@@ -29,10 +29,9 @@ import {
 } from '../../utilities/richTextConversion'
 
 import { Config, CrowdinFile } from "../../payload-types";
-import { getFile, getFileByDocumentID, getFileByParent, getFiles, getFilesByDocumentID, getFilesByParent } from "../helpers";
+import { getFileByDocumentID, getFileByParent, getFilesByDocumentID, getFilesByParent } from "../helpers";
 import { getLexicalBlockFields, getLexicalEditorConfig } from "../../utilities/lexical";
 import { getRelationshipId } from "../../utilities/payload";
-import { SerializedBlockNode } from "@payloadcms/richtext-lexical";
 
 interface IgetLatestDocumentTranslation {
   collection: string;

--- a/plugin/src/lib/api/payload-crowdin-sync/translations.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/translations.ts
@@ -28,7 +28,7 @@ import {
 } from '../../utilities/richTextConversion'
 
 import { Config, CrowdinFile } from "../../payload-types";
-import { getFile, getFileByDocumentID, getFiles, getFilesByDocumentID } from "../helpers";
+import { getFile, getFileByDocumentID, getFileByParent, getFiles, getFilesByDocumentID } from "../helpers";
 import { getLexicalBlockFields, getLexicalEditorConfig } from "../../utilities/lexical";
 import { getRelationshipId } from "../../utilities/payload";
 
@@ -347,7 +347,7 @@ export class payloadCrowdinSyncTranslationsApi {
    */
   // TODO refactor out fields override - replace `collection` with `fields`
   async getTranslation({ documentId, fieldName, locale, collection, parentCrowdinArticleDirectoryId, fields }: IgetTranslation) {
-    const file = (typeof parentCrowdinArticleDirectoryId === 'string' ? await getFile(fieldName, parentCrowdinArticleDirectoryId, this.payload) : await getFileByDocumentID(fieldName, `${documentId}`, this.payload)) as CrowdinFile;
+    const file = (typeof parentCrowdinArticleDirectoryId === 'string' ? await getFileByParent(fieldName, parentCrowdinArticleDirectoryId, this.payload) : await getFileByDocumentID(fieldName, `${documentId}`, this.payload)) as CrowdinFile;
     // it is possible a file doesn't exist yet - e.g. an article with localized text fields that contains an empty html field.
     if (!file) {
       return;
@@ -391,7 +391,7 @@ export class payloadCrowdinSyncTranslationsApi {
               (await this.getTranslation({
                 // field name in dot notation is the 'id' for getTranslation
                 documentId: fieldName,
-                fieldName: "fields",
+                fieldName: "blocks",
                 locale: locale,
                 parentCrowdinArticleDirectoryId: getRelationshipId(file.crowdinArticleDirectory),
 
@@ -413,9 +413,10 @@ export class payloadCrowdinSyncTranslationsApi {
               crowdinJsonObject,
               crowdinHtmlObject,
               fields,
+              filterLocalizedFields: false,
             });
 
-            console.log(docTranslations)
+            console.log('crowdinJsonObject', crowdinJsonObject, 'crowdinHtmlObject', crowdinHtmlObject, 'fields', fields, 'docTranslations', docTranslations)
 
             return convertHtmlToLexical(data, editorConfig, getRelationshipId(file.crowdinArticleDirectory)) || {
               "root": {

--- a/plugin/src/lib/plugin.ts
+++ b/plugin/src/lib/plugin.ts
@@ -14,7 +14,6 @@ import { containsLocalizedFields } from "./utilities";
 import { getReviewTranslationEndpoint } from "./endpoints/globals/reviewTranslation";
 import { getReviewFieldsEndpoint } from "./endpoints/globals/reviewFields";
 import Joi from "joi";
-import { isArray } from "lodash";
 import { crowdinArticleDirectoryFields } from "./fields/crowdinArticleDirectoryFields";
 
 /**

--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -24,15 +24,17 @@ export const findField = ({
   dotNotation,
   fields,
   firstIteration = true,
+  filterLocalizedFields = true,
 }: {
   dotNotation: string
   fields: Field[]
   firstIteration?: boolean,
+  filterLocalizedFields?: boolean,
 }): Field | undefined => {
   /** Run through getLocalizedFields to ignore tabs/collapssibles...etc */
-  const localizedFields = firstIteration ? getLocalizedFields({
+  const localizedFields = filterLocalizedFields ? (firstIteration ? getLocalizedFields({
     fields
-  }) : fields
+  }) : fields) : fields
   const keys = dotNotation.split(`.`)
   if (keys.length === 0) {
     return undefined

--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -411,6 +411,7 @@ export const buildPayloadUpdateObject = ({
   fields,
   topLevel = true,
   document,
+  filterLocalizedFields = true,
 }: {
   crowdinJsonObject: { [key: string]: any };
   crowdinHtmlObject?: CrowdinHtmlObject;
@@ -419,6 +420,7 @@ export const buildPayloadUpdateObject = ({
   /** Flag used internally to filter json fields before recursion. */
   topLevel?: boolean;
   document?: { [key: string]: any };
+  filterLocalizedFields?: boolean;
 }) => {
   let response: { [key: string]: any } = {};
   if (crowdinHtmlObject) {
@@ -426,12 +428,12 @@ export const buildPayloadUpdateObject = ({
 
     merge(crowdinJsonObject, destructured);
   }
-  const filteredFields = topLevel
+  const filteredFields = filterLocalizedFields ? (topLevel
     ? getLocalizedFields({
         fields,
         type: !crowdinHtmlObject ? "json" : undefined,
       })
-    : fields;
+    : fields) : fields;
   filteredFields.forEach((field) => {
     if (!crowdinJsonObject[field.name]) {
       return;

--- a/plugin/src/lib/utilities/lexical/slateBlockConverter.ts
+++ b/plugin/src/lib/utilities/lexical/slateBlockConverter.ts
@@ -3,15 +3,12 @@ import type { SlateNodeConverter } from '@payloadcms/richtext-lexical'
 
 export const SlateBlockConverter: SlateNodeConverter = {
   converter({ slateNode }) {
-
-
     return {
-      fields: {
-      },
+      fields: slateNode['translation'],
       format: '',
-      type: 'block',
+      type: slateNode['translation'] ? 'block' : 'noTranslation',
       version: 2,
     } as const as SerializedBlockNode
   },
-  nodeTypes: ['upload'],
+  nodeTypes: ['pcs-block'],
 }

--- a/plugin/src/lib/utilities/lexical/slateBlockConverter.ts
+++ b/plugin/src/lib/utilities/lexical/slateBlockConverter.ts
@@ -1,7 +1,7 @@
 import type { SerializedBlockNode } from "@payloadcms/richtext-lexical"
 import type { SlateNodeConverter } from '@payloadcms/richtext-lexical'
 
-export const SlateUploadConverter: SlateNodeConverter = {
+export const SlateBlockConverter: SlateNodeConverter = {
   converter({ slateNode }) {
 
 

--- a/plugin/src/lib/utilities/lexical/slateBlockConverter.ts
+++ b/plugin/src/lib/utilities/lexical/slateBlockConverter.ts
@@ -1,0 +1,17 @@
+import type { SerializedBlockNode } from "@payloadcms/richtext-lexical"
+import type { SlateNodeConverter } from '@payloadcms/richtext-lexical'
+
+export const SlateUploadConverter: SlateNodeConverter = {
+  converter({ slateNode }) {
+
+
+    return {
+      fields: {
+      },
+      format: '',
+      type: 'block',
+      version: 2,
+    } as const as SerializedBlockNode
+  },
+  nodeTypes: ['upload'],
+}

--- a/plugin/src/lib/utilities/payload.ts
+++ b/plugin/src/lib/utilities/payload.ts
@@ -1,0 +1,15 @@
+import { CrowdinArticleDirectory } from "../payload-types";
+
+export const isNotString = <T>(val: T | string | undefined | null): val is T => {
+  return val !== undefined && val !== null && typeof val !== 'string';
+};
+
+export const getRelationshipId = (relationship?: string | CrowdinArticleDirectory | null) => {
+  if (!relationship) {
+    return undefined
+  }
+  if (isNotString(relationship)) {
+    return relationship.id
+  }
+  return relationship
+}

--- a/plugin/src/lib/utilities/richTextConversion.ts
+++ b/plugin/src/lib/utilities/richTextConversion.ts
@@ -46,7 +46,9 @@ export const convertLexicalToHtml = async (editorData: SerializedEditorState, ed
   })
 }
 
-export const convertHtmlToLexical = (htmlString: string, editorConfig: SanitizedEditorConfig, crowdinArticleDirectoryId?: string) => {
+export const convertHtmlToLexical = (htmlString: string, editorConfig: SanitizedEditorConfig, blockTranslations?: {
+  [key: string]: any;
+} | null) => {
   // use editorConfig to determine custom convertors
   const converters = cloneDeep([
     ...defaultSlateConverters,
@@ -61,14 +63,13 @@ export const convertHtmlToLexical = (htmlString: string, editorConfig: Sanitized
       span: (el) => {
         const blockId = el && getAttributeValue(el, 'data-block-id')
         const blockType = el && getAttributeValue(el, 'data-block-type')
-        const blockConfig = getLexicalBlockFields(editorConfig).blocks.filter(block => block.slug === blockType)
+        const translation = (blockTranslations?.['blocks'] || []).find((block: any) => block.id === blockId)
 
           return {
           // use a relatively obscure name to reduce likelihood of a clash with an existing Slate editor configuration `nodeType`.
           type: 'pcs-block',
           // fieldName needed to obtain translations?
-          crowdinArticleDirectoryId,
-          blockConfig,
+          translation,
           blockId,
           blockType,
         }

--- a/plugin/src/lib/utilities/richTextConversion.ts
+++ b/plugin/src/lib/utilities/richTextConversion.ts
@@ -25,9 +25,6 @@ import {
 
 import { getAttributeValue } from 'domutils'
 import { SlateBlockConverter } from "./lexical/slateBlockConverter";
-import { getLexicalBlockFields } from "./lexical";
-import { Field } from "payload/types";
-import { payloadCrowdinSyncTranslationsApi } from "../api/payload-crowdin-sync/translations";
 
 const BlockHTMLConverter: HTMLConverter<any> = {
   converter: async ({ node }) => {

--- a/plugin/src/lib/utilities/richTextConversion.ts
+++ b/plugin/src/lib/utilities/richTextConversion.ts
@@ -23,6 +23,8 @@ import {
   defaultSlateConverters,
 } from '@payloadcms/richtext-lexical'
 
+import { getAttributeValue } from 'domutils'
+
 const BlockHTMLConverter: HTMLConverter<any> = {
   converter: async ({ node }) => {
     return `<span data-block-id=${node.fields.id}></span>`
@@ -46,9 +48,19 @@ export const convertHtmlToLexical = (htmlString: string, editorConfig: Sanitized
     ...defaultSlateConverters,
     // AnotherCustomConverter
   ])
+  const htmlToSlateConfig = {
+    ...payloadHtmlToSlateConfig,
+    elementTags: {
+      ...payloadHtmlToSlateConfig.elementTags,
+      span: (el) => ({
+        type: 'block',
+        id: el && getAttributeValue(el, 'data-block-id'),
+      }),
+    },
+  } as HtmlToSlateConfig
   return convertSlateToLexical({
     converters: converters,
-    slateData: convertHtmlToSlate(htmlString),
+    slateData: convertHtmlToSlate(htmlString, htmlToSlateConfig),
   })
 }
 


### PR DESCRIPTION
Load translations for blocks inside Lexical `richText` fields. Builds on the feature added in https://github.com/thompsonsj/payload-crowdin-sync/pull/161 which sends Lexical `richText` field blocks for translation.

## Robust nock tests

Note how adding this functionality means that we now need to mock the response from translation calls for files created in dev/src/lib/tests/fields/lexical-editor-with-multiple-blocks.test.ts.

This is a nice justification for all the effort that went into building tests with `nock` and making sure all Crowdin API calls are intercepted and the exact number are intercepted. We are now making a call for translations for two additional files because block translation functionality is added, and tests are updated to reflect this. With so many API calls/recursion/transforming happening in the background, it is refreshing to be able to review these tests and see the end result happening with API calls.