### PR TITLE
refactor(nestedfieldcollection): update translation, pass req object

### DIFF
--- a/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
+++ b/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
@@ -1,6 +1,6 @@
 import payload from 'payload';
 import { initPayloadTest } from '../helpers/config';
-import { getArticleDirectory, payloadCrowdinSyncTranslationsApi, utilities } from 'plugin';
+import { payloadCrowdinSyncTranslationsApi, utilities } from 'plugin';
 import NestedFieldCollection from '../../collections/NestedFieldCollection';
 import { fixture } from './lexical-editor-with-blocks-inside-array.fixture';
 import nock from 'nock';
@@ -704,30 +704,27 @@ describe('Lexical editor with multiple blocks', () => {
 
     expect(files.length).toEqual(3);
 
-    expect(files[0].fileData).toEqual(
-      {
-        "html": `<p>If you add custom blocks, these will also be translated!</p><span data-block-id=${lexicalBlockIds[0]} data-block-type=highlight></span>`,
-      }
-    );
+    expect(files[0].fileData).toEqual({
+      html: `<p>If you add custom blocks, these will also be translated!</p><span data-block-id=${lexicalBlockIds[0]} data-block-type=highlight></span>`,
+    });
     expect(files[1].fileData).toMatchInlineSnapshot(`
       {
         "html": "<p>Lexical fields nested within complex layouts - such as this one (a <code>blocks</code> field in an <code>array</code> item within a <code>tab</code>), are supported.</p>",
       }
     `);
-    expect(files[2].fileData).toEqual(
-      {
-        "json": {
-          "items": {
-            [`${arrayIds[0]}`]: {
-              "heading": "Nested Lexical fields are supported",
-            },
-            [`${arrayIds[1]}`]: {
-              "heading": "Nested Lexical fields are supported - and blocks in that Lexical field are also translated",
-            },
+    expect(files[2].fileData).toEqual({
+      json: {
+        items: {
+          [`${arrayIds[0]}`]: {
+            heading: 'Nested Lexical fields are supported',
+          },
+          [`${arrayIds[1]}`]: {
+            heading:
+              'Nested Lexical fields are supported - and blocks in that Lexical field are also translated',
           },
         },
-      }
-    );
+      },
+    });
   });
 
   it('creates files for Lexical block with expected data', async () => {
@@ -835,10 +832,39 @@ describe('Lexical editor with multiple blocks', () => {
       .reply(
         200,
         mockClient.createFile({
-          fileId: 48314,
+          fileId: 48315,
         })
-      )
-      // fr - file 1 get translation
+      );
+
+    const doc: NestedFieldCollectionType = (await payload.create({
+      collection: 'nested-field-collection',
+      data: fixture,
+    })) as any;
+
+    const updatedDoc = (await payload.update({
+      id: doc.id,
+      collection: 'nested-field-collection',
+      data: {
+        title: 'Update required to access the crowdinArticleDirectory?',
+      },
+    })) as any;
+
+    const arrayIds =
+      (doc.items || []).map((item) => item.id) || ([] as string[]);
+    const blockIds =
+      (doc.items || []).map(
+        (item) => (item.block || []).find((x) => x !== undefined)?.id
+      ) || ([] as string[]);
+    const firstLexicalBlock = doc.items?.[1]?.block?.[0]?.content;
+
+    const lexicalBlockIds = firstLexicalBlock
+      ? extractLexicalBlockContent(firstLexicalBlock.root).map(
+          (block) => block.id
+        )
+      : ['lexical-block-id-not-found'];
+
+    // fr - file 1 get translation
+    nock('https://api.crowdin.com')
       .post(
         `/api/v2/projects/${
           pluginOptions.projectId
@@ -863,7 +889,17 @@ describe('Lexical editor with multiple blocks', () => {
       .query({
         targetLanguageId: 'fr',
       })
-      .reply(200, {})
+      .reply(200, {
+        items: {
+          [`${arrayIds[0]}`]: {
+            heading: 'Les champs lexicaux imbriqués sont pris en charge',
+          },
+          [`${arrayIds[1]}`]: {
+            heading:
+              'Les champs lexicaux imbriqués sont pris en charge - et les blocs de ce champ lexical sont également traduits',
+          },
+        },
+      })
       // fr - file 2 get translation
       .post(
         `/api/v2/projects/${
@@ -889,7 +925,10 @@ describe('Lexical editor with multiple blocks', () => {
       .query({
         targetLanguageId: 'fr',
       })
-      .reply(200, {})
+      .reply(
+        200,
+        '<p>Les champs lexicaux imbriqués dans des mises en page complexes - comme celui-ci (un champ <code>blocks</code> dans un élément <code>array</code> dans un <code>onglet</code>), sont pris en charge.</p>'
+      )
       // fr - file 3 get translation
       .post(
         `/api/v2/projects/${
@@ -899,6 +938,8 @@ describe('Lexical editor with multiple blocks', () => {
           targetLanguageId: 'fr',
         }
       )
+      // TODO: figure out why twice?
+      .twice()
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
@@ -912,13 +953,22 @@ describe('Lexical editor with multiple blocks', () => {
           pluginOptions.projectId
         }/translations/builds/${48313}/download`
       )
+      // TODO: figure out why twice?
+      .twice()
       .query({
         targetLanguageId: 'fr',
       })
-      .reply(
-        200,
-        ""
-      )
+      .reply(200, {
+        blocks: {
+          [`${lexicalBlockIds[0]}`]: {
+            highlight: {
+              heading: {
+                title: 'Configuration des blocs dans les champs lexicaux',
+              },
+            },
+          },
+        },
+      })
       // fr - file 4 get translation
       .post(
         `/api/v2/projects/${
@@ -928,6 +978,8 @@ describe('Lexical editor with multiple blocks', () => {
           targetLanguageId: 'fr',
         }
       )
+      // TODO: figure out why twice?
+      .twice()
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
@@ -941,12 +993,14 @@ describe('Lexical editor with multiple blocks', () => {
           pluginOptions.projectId
         }/translations/builds/${48314}/download`
       )
+      // TODO: figure out why twice?
+      .twice()
       .query({
         targetLanguageId: 'fr',
       })
       .reply(
         200,
-        ``
+        `<p>Notez une différence clé avec les blocs normaux : tous les champs <code>text</code>, <code>textarea</code> et <code>richText</code> seront envoyés à Crowdin, qu'ils soient ou non <a href="https://payloadcms.com/docs/configuration/localization#field-by-field-localization">champs localisés</a>.</p>`
       )
       // fr - file 5 get translation
       .post(
@@ -975,34 +1029,15 @@ describe('Lexical editor with multiple blocks', () => {
       })
       .reply(
         200,
-        ``
+        `<p>Si vous ajoutez des blocs personnalisés, ceux-ci seront également traduits !</p><span data-block-id=${lexicalBlockIds[0]} data-block-type=highlight></span>`
       );
-
-    const doc: NestedFieldCollectionType = await payload.create({
-      collection: 'nested-field-collection',
-      data: fixture,
-    }) as any;
-
-    const arrayIds =
-      (doc.items || []).map((item) => item.id) || ([] as string[]);
-    const blockIds =
-      (doc.items || []).map(
-        (item) => (item.block || []).find((x) => x !== undefined)?.id
-      ) || ([] as string[]);
-    const firstLexicalBlock = doc.items?.[1]?.block?.[0]?.content;
-
-    const lexicalBlockIds = firstLexicalBlock
-      ? extractLexicalBlockContent(firstLexicalBlock.root).map(
-          (block) => block.id
-        )
-      : ['lexical-block-id-not-found'];
 
     const crowdinFiles = await getFilesByDocumentID(`${doc.id}`, payload);
     const contentCrowdinFiles = await getFilesByParent(
-      `${getRelationshipId(doc.crowdinArticleDirectory)}`,
+      `${getRelationshipId(updatedDoc.crowdinArticleDirectory)}`,
       payload
     );
-console.log('contentCrowdinFiles', contentCrowdinFiles)
+
     // check file ids are always mapped in the same way
     const fileIds = crowdinFiles.map((file) => ({
       fileId: file.originalId,
@@ -1015,7 +1050,7 @@ console.log('contentCrowdinFiles', contentCrowdinFiles)
     expect(fileIds).toEqual([
       {
         field: `items.${arrayIds[1]}.block.${blockIds[1]}.basicBlockLexical.content`,
-        fileId: 48314,
+        fileId: 48315,
       },
       {
         field: `items.${arrayIds[0]}.block.${blockIds[0]}.basicBlockLexical.content`,
@@ -1029,11 +1064,11 @@ console.log('contentCrowdinFiles', contentCrowdinFiles)
     expect(contentFileIds).toEqual([
       {
         field: `blocks.${lexicalBlockIds[0]}.highlight.content`,
-        fileId: 48313,
+        fileId: 48314,
       },
       {
         field: 'blocks',
-        fileId: 48315,
+        fileId: 48313,
       },
     ]);
     const translationsApi = new payloadCrowdinSyncTranslationsApi(
@@ -1052,6 +1087,269 @@ console.log('contentCrowdinFiles', contentCrowdinFiles)
       id: `${doc.id}`,
       locale: 'fr_FR',
     });
-    expect(result['items']).toMatchInlineSnapshot();
+    expect(result['items']).toEqual(
+      [
+        {
+          "block": [
+            {
+              "blockType": "basicBlockLexical",
+              "content": {
+                "root": {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "detail": 0,
+                          "format": 0,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "Les champs lexicaux imbriqués dans des mises en page complexes - comme celui-ci (un champ ",
+                          "type": "text",
+                          "version": 1,
+                        },
+                        {
+                          "detail": 0,
+                          "format": 16,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "blocks",
+                          "type": "text",
+                          "version": 1,
+                        },
+                        {
+                          "detail": 0,
+                          "format": 0,
+                          "mode": "normal",
+                          "style": "",
+                          "text": " dans un élément ",
+                          "type": "text",
+                          "version": 1,
+                        },
+                        {
+                          "detail": 0,
+                          "format": 16,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "array",
+                          "type": "text",
+                          "version": 1,
+                        },
+                        {
+                          "detail": 0,
+                          "format": 0,
+                          "mode": "normal",
+                          "style": "",
+                          "text": " dans un ",
+                          "type": "text",
+                          "version": 1,
+                        },
+                        {
+                          "detail": 0,
+                          "format": 16,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "onglet",
+                          "type": "text",
+                          "version": 1,
+                        },
+                        {
+                          "detail": 0,
+                          "format": 0,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "), sont pris en charge.",
+                          "type": "text",
+                          "version": 1,
+                        },
+                      ],
+                      "direction": "ltr",
+                      "format": "",
+                      "indent": 0,
+                      "type": "paragraph",
+                      "version": 1,
+                    },
+                  ],
+                  "direction": "ltr",
+                  "format": "",
+                  "indent": 0,
+                  "type": "root",
+                  "version": 1,
+                },
+              },
+              "id": `${blockIds[0]}`,
+            },
+          ],
+          "heading": "Les champs lexicaux imbriqués sont pris en charge",
+          "id": `${arrayIds[0]}`,
+        },
+        {
+          "block": [
+            {
+              "blockType": "basicBlockLexical",
+              "content": {
+                "root": {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "detail": 0,
+                          "format": 0,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "Si vous ajoutez des blocs personnalisés, ceux-ci seront également traduits !",
+                          "type": "text",
+                          "version": 1,
+                        },
+                      ],
+                      "direction": "ltr",
+                      "format": "",
+                      "indent": 0,
+                      "type": "paragraph",
+                      "version": 1,
+                    },
+                    {
+                      "fields": {
+                        "blockType": "highlight",
+                        "content": {
+                          "root": {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "detail": 0,
+                                    "format": 0,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": "Notez une différence clé avec les blocs normaux : tous les champs ",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                  {
+                                    "detail": 0,
+                                    "format": 16,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": "text",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                  {
+                                    "detail": 0,
+                                    "format": 0,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": ", ",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                  {
+                                    "detail": 0,
+                                    "format": 16,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": "textarea",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                  {
+                                    "detail": 0,
+                                    "format": 0,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": " et ",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                  {
+                                    "detail": 0,
+                                    "format": 16,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": "richText",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                  {
+                                    "detail": 0,
+                                    "format": 0,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": " seront envoyés à Crowdin, qu'ils soient ou non ",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "detail": 0,
+                                        "format": 0,
+                                        "mode": "normal",
+                                        "style": "",
+                                        "text": "champs localisés",
+                                        "type": "text",
+                                        "version": 1,
+                                      },
+                                    ],
+                                    "direction": "ltr",
+                                    "fields": {
+                                      "doc": null,
+                                      "linkType": "custom",
+                                      "newTab": false,
+                                      "url": "https://payloadcms.com/docs/configuration/localization#field-by-field-localization",
+                                    },
+                                    "format": "",
+                                    "indent": 0,
+                                    "type": "link",
+                                    "version": 2,
+                                  },
+                                  {
+                                    "detail": 0,
+                                    "format": 0,
+                                    "mode": "normal",
+                                    "style": "",
+                                    "text": ".",
+                                    "type": "text",
+                                    "version": 1,
+                                  },
+                                ],
+                                "direction": "ltr",
+                                "format": "",
+                                "indent": 0,
+                                "type": "paragraph",
+                                "version": 1,
+                              },
+                            ],
+                            "direction": "ltr",
+                            "format": "",
+                            "indent": 0,
+                            "type": "root",
+                            "version": 1,
+                          },
+                        },
+                        "heading": {
+                          "title": "Configuration des blocs dans les champs lexicaux",
+                        },
+                        "id": `${lexicalBlockIds[0]}`,
+                      },
+                      "format": "",
+                      "type": "block",
+                      "version": 2,
+                    },
+                  ],
+                  "direction": "ltr",
+                  "format": "",
+                  "indent": 0,
+                  "type": "root",
+                  "version": 1,
+                },
+              },
+              "id": `${blockIds[1]}`,
+            },
+          ],
+          "heading": "Les champs lexicaux imbriqués sont pris en charge - et les blocs de ce champ lexical sont également traduits",
+          "id": `${arrayIds[1]}`,
+        },
+      ]
+    );
   });
 });

--- a/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
+++ b/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
@@ -1,6 +1,6 @@
 import payload from 'payload';
 import { initPayloadTest } from '../helpers/config';
-import { getArticleDirectory, utilities } from 'plugin';
+import { getArticleDirectory, payloadCrowdinSyncTranslationsApi, utilities } from 'plugin';
 import NestedFieldCollection from '../../collections/NestedFieldCollection';
 import { fixture } from './lexical-editor-with-blocks-inside-array.fixture';
 import nock from 'nock';
@@ -692,10 +692,6 @@ describe('Lexical editor with multiple blocks', () => {
 
     const arrayIds =
       (doc.items || []).map((item) => item.id) || ([] as string[]);
-    const blockIds =
-      (doc.items || []).map(
-        (item) => (item.block || []).find((x) => x !== undefined)?.id
-      ) || ([] as string[]);
     const firstLexicalBlock = doc.items?.[1]?.block?.[0]?.content;
 
     const lexicalBlockIds = firstLexicalBlock
@@ -792,5 +788,270 @@ describe('Lexical editor with multiple blocks', () => {
         },
       }
     `);
+  });
+
+  it('updates the Payload document with a translation from Crowdin', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .twice()
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .times(5)
+      .reply(200, mockClient.addStorage())
+      // file 1 creation
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .reply(
+        200,
+        mockClient.createFile({
+          fileId: 48311,
+        })
+      )
+      // file 2 creation
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .reply(
+        200,
+        mockClient.createFile({
+          fileId: 48312,
+        })
+      )
+      // file 3 creation
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .reply(
+        200,
+        mockClient.createFile({
+          fileId: 48313,
+        })
+      )
+      // file 4 creation
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .reply(
+        200,
+        mockClient.createFile({
+          fileId: 48314,
+        })
+      )
+      // file 5 creation
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .reply(
+        200,
+        mockClient.createFile({
+          fileId: 48314,
+        })
+      )
+      // fr - file 1 get translation
+      .post(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/files/${48311}`,
+        {
+          targetLanguageId: 'fr',
+        }
+      )
+      .reply(
+        200,
+        mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${
+            pluginOptions.projectId
+          }/translations/builds/${48311}/download?targetLanguageId=fr`,
+        })
+      )
+      .get(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${48311}/download`
+      )
+      .query({
+        targetLanguageId: 'fr',
+      })
+      .reply(200, {})
+      // fr - file 2 get translation
+      .post(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/files/${48312}`,
+        {
+          targetLanguageId: 'fr',
+        }
+      )
+      .reply(
+        200,
+        mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${
+            pluginOptions.projectId
+          }/translations/builds/${48312}/download?targetLanguageId=fr`,
+        })
+      )
+      .get(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${48312}/download`
+      )
+      .query({
+        targetLanguageId: 'fr',
+      })
+      .reply(200, {})
+      // fr - file 3 get translation
+      .post(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/files/${48313}`,
+        {
+          targetLanguageId: 'fr',
+        }
+      )
+      .reply(
+        200,
+        mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${
+            pluginOptions.projectId
+          }/translations/builds/${48313}/download?targetLanguageId=fr`,
+        })
+      )
+      .get(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${48313}/download`
+      )
+      .query({
+        targetLanguageId: 'fr',
+      })
+      .reply(
+        200,
+        ""
+      )
+      // fr - file 4 get translation
+      .post(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/files/${48314}`,
+        {
+          targetLanguageId: 'fr',
+        }
+      )
+      .reply(
+        200,
+        mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${
+            pluginOptions.projectId
+          }/translations/builds/${48314}/download?targetLanguageId=fr`,
+        })
+      )
+      .get(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${48314}/download`
+      )
+      .query({
+        targetLanguageId: 'fr',
+      })
+      .reply(
+        200,
+        ``
+      )
+      // fr - file 5 get translation
+      .post(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/files/${48315}`,
+        {
+          targetLanguageId: 'fr',
+        }
+      )
+      .reply(
+        200,
+        mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${
+            pluginOptions.projectId
+          }/translations/builds/${48315}/download?targetLanguageId=fr`,
+        })
+      )
+      .get(
+        `/api/v2/projects/${
+          pluginOptions.projectId
+        }/translations/builds/${48315}/download`
+      )
+      .query({
+        targetLanguageId: 'fr',
+      })
+      .reply(
+        200,
+        ``
+      );
+
+    const doc: NestedFieldCollectionType = await payload.create({
+      collection: 'nested-field-collection',
+      data: fixture,
+    }) as any;
+
+    const arrayIds =
+      (doc.items || []).map((item) => item.id) || ([] as string[]);
+    const blockIds =
+      (doc.items || []).map(
+        (item) => (item.block || []).find((x) => x !== undefined)?.id
+      ) || ([] as string[]);
+    const firstLexicalBlock = doc.items?.[1]?.block?.[0]?.content;
+
+    const lexicalBlockIds = firstLexicalBlock
+      ? extractLexicalBlockContent(firstLexicalBlock.root).map(
+          (block) => block.id
+        )
+      : ['lexical-block-id-not-found'];
+
+    const crowdinFiles = await getFilesByDocumentID(`${doc.id}`, payload);
+    const contentCrowdinFiles = await getFilesByParent(
+      `${getRelationshipId(doc.crowdinArticleDirectory)}`,
+      payload
+    );
+console.log('contentCrowdinFiles', contentCrowdinFiles)
+    // check file ids are always mapped in the same way
+    const fileIds = crowdinFiles.map((file) => ({
+      fileId: file.originalId,
+      field: file.field,
+    }));
+    const contentFileIds = contentCrowdinFiles.map((file) => ({
+      fileId: file.originalId,
+      field: file.field,
+    }));
+    expect(fileIds).toEqual([
+      {
+        field: `items.${arrayIds[1]}.block.${blockIds[1]}.basicBlockLexical.content`,
+        fileId: 48314,
+      },
+      {
+        field: `items.${arrayIds[0]}.block.${blockIds[0]}.basicBlockLexical.content`,
+        fileId: 48312,
+      },
+      {
+        field: 'fields',
+        fileId: 48311,
+      },
+    ]);
+    expect(contentFileIds).toEqual([
+      {
+        field: `blocks.${lexicalBlockIds[0]}.highlight.content`,
+        fileId: 48313,
+      },
+      {
+        field: 'blocks',
+        fileId: 48315,
+      },
+    ]);
+    const translationsApi = new payloadCrowdinSyncTranslationsApi(
+      pluginOptions,
+      payload
+    );
+    await translationsApi.updateTranslation({
+      documentId: `${doc.id}`,
+      collection: 'nested-field-collection',
+      dryRun: false,
+      excludeLocales: ['de_DE'],
+    });
+    // retrieve translated post from Payload
+    const result = await payload.findByID({
+      collection: 'nested-field-collection',
+      id: `${doc.id}`,
+      locale: 'fr_FR',
+    });
+    expect(result['items']).toMatchInlineSnapshot();
   });
 });

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -1,8 +1,7 @@
 import { PluginOptions } from '../../../index';
 import { payloadCrowdinSyncFilesApi } from ".";
-import { Payload } from "payload";
 import { CrowdinArticleDirectory, CrowdinFile } from './../../../payload-types';
-import { CollectionConfig, Document, GlobalConfig, RichTextField } from 'payload/types';
+import { CollectionConfig, Document, GlobalConfig, PayloadRequest, RichTextField } from 'payload/types';
 import { Config } from 'payload/config';
 
 import { isEmpty } from 'lodash';
@@ -41,8 +40,8 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
     articleDirectory: CrowdinArticleDirectory,
     collectionSlug:  keyof Config['collections'] | "globals",
     global: boolean,
-  }, pluginOptions: PluginOptions, payload: Payload) {
-    super(pluginOptions, payload);
+  }, pluginOptions: PluginOptions, req: PayloadRequest) {
+    super(pluginOptions, req);
     this.document = document
     this.articleDirectory = articleDirectory
     this.collectionSlug = collectionSlug
@@ -58,7 +57,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
    * @returns CrowdinFile
    */
   async getFile(name: string): Promise<CrowdinFile> {
-    return getFile(name, this.articleDirectory.id, this.payload);
+    return getFile(name, this.articleDirectory.id, this.req.payload);
   }
 
   /**
@@ -69,7 +68,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
    * @returns CrowdinFile[]
    */
   async getFiles(): Promise<CrowdinFile[]> {
-    return getFiles(this.articleDirectory.id, this.payload);
+    return getFiles(this.articleDirectory.id, this.req.payload);
   }
 
   /**
@@ -127,7 +126,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
       fileType,
     });
 
-    await this.payload.update({
+    await this.req.payload.update({
       collection: "crowdin-files", // required
       id: crowdinFile.id,
       data: {
@@ -139,6 +138,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
         }) }}),
         ...(fileType === "html" && { fileData: { html: typeof fileData === 'string' ? fileData : JSON.stringify(fileData) } }),
       },
+      req: this.req,
     });
   }
 
@@ -158,7 +158,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
       });
       // Store result on Payload CMS
       if (crowdinFile) {
-        const payloadCrowdinFile = await this.payload.create({
+        const payloadCrowdinFile = await this.req.payload.create({
           collection: "crowdin-files", // required
           data: {
             // required
@@ -181,6 +181,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
             }) } }),
             ...(fileType === "html" && { fileData: { html: typeof fileData === 'string' ? fileData : JSON.stringify(fileData) } }),
           },
+          req: this.req,
         });
         return payloadCrowdinFile;
       }
@@ -193,9 +194,10 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
       this.projectId,
       crowdinFile.originalId as number
     );
-    const payloadFile = await this.payload.delete({
+    const payloadFile = await this.req.payload.delete({
       collection: "crowdin-files", // required
       id: crowdinFile.id, // required
+      req: this.req,
     });
     return payloadFile;
   }
@@ -203,9 +205,11 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
   async createOrUpdateJsonFile({
     fileData,
     fileName = "fields",
+    req,
   }: {
     fileData: FileData,
     fileName?: string,
+    req?: PayloadRequest
   }) {
     await this.createOrUpdateFile({
       name: fileName,
@@ -243,10 +247,14 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
           const folderName = `${this.pluginOptions.lexicalBlockFolderPrefix}${name}`
           const blockConfig = getLexicalBlockFields(editorConfig)
           
+          if (!blockConfig) {
+            return
+          }
+
           /**
            * Initialize Crowdin client sourceFilesApi
            */
-          const crowdinArticleDirectory = await getArticleDirectory(folderName, this.payload, false, this.articleDirectory)
+          const crowdinArticleDirectory = await getArticleDirectory(folderName, this.req.payload, false, this.articleDirectory)
           const apiByDocument = new filesApiByDocument(
             {
               document: {
@@ -259,40 +267,40 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
               collectionSlug: collection.slug as keyof Config['collections'] | keyof Config['globals'],
               global: false,
               pluginOptions: this.pluginOptions,
-              payload: this.payload,
+              req: this.req,
               /** Important: Identify that this article directory has a parent - logic changes for non-top-level directories. */
               parent: this.articleDirectory,
             },
           );
           const filesApi = await apiByDocument.get()
 
-          const fieldName = `blocks`
-          const currentCrowdinJsonData = buildCrowdinJsonObject({
-            doc: {
-              [fieldName]: blockContent,
-            },
-            fields: [
-              {
-                name: fieldName,
-                type: 'blocks',
-                blocks: blockConfig.blocks,
-              }
-            ],
-            isLocalized: reLocalizeField, // ignore localized attribute
-          });
-          const currentCrowdinHtmlData = buildCrowdinHtmlObject({
-            doc: {
-              [fieldName]: blockContent,
-            },
-            fields: [
-              {
-                name: fieldName,
-                type: 'blocks',
-                blocks: blockConfig.blocks,
-              }
-            ],
-            isLocalized: reLocalizeField, // ignore localized attribute
-          });
+            const fieldName = `blocks`
+            const currentCrowdinJsonData = buildCrowdinJsonObject({
+              doc: {
+                [fieldName]: blockContent,
+              },
+              fields: [
+                {
+                  name: fieldName,
+                  type: 'blocks',
+                  blocks: blockConfig.blocks,
+                }
+              ],
+              isLocalized: reLocalizeField, // ignore localized attribute
+            });
+            const currentCrowdinHtmlData = buildCrowdinHtmlObject({
+              doc: {
+                [fieldName]: blockContent,
+              },
+              fields: [
+                {
+                  name: fieldName,
+                  type: 'blocks',
+                  blocks: blockConfig.blocks,
+                }
+              ],
+              isLocalized: reLocalizeField, // ignore localized attribute
+            });
           await filesApi.createOrUpdateJsonFile({
             fileData: currentCrowdinJsonData,
             fileName: fieldName,

--- a/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/document.ts
@@ -200,7 +200,13 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
     return payloadFile;
   }
 
-  async createOrUpdateJsonFile(fileData: FileData, fileName = "fields") {
+  async createOrUpdateJsonFile({
+    fileData,
+    fileName = "fields",
+  }: {
+    fileData: FileData,
+    fileName?: string,
+  }) {
     await this.createOrUpdateFile({
       name: fileName,
       fileData,
@@ -287,7 +293,10 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
             ],
             isLocalized: reLocalizeField, // ignore localized attribute
           });
-          await filesApi.createOrUpdateJsonFile(currentCrowdinJsonData, fieldName);
+          await filesApi.createOrUpdateJsonFile({
+            fileData: currentCrowdinJsonData,
+            fileName: fieldName,
+          });
           await Promise.all(Object.keys(currentCrowdinHtmlData).map(async (name) => {
             await filesApi.createOrUpdateHtmlFile({
               name,

--- a/plugin/src/lib/api/payload-crowdin-sync/files/index.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/index.ts
@@ -3,7 +3,6 @@ import crowdin, {
   SourceFiles,
   UploadStorage,
 } from "@crowdin/crowdin-api-client";
-import { Payload } from "payload";
 import { PluginOptions } from "../../../types";
 import {
   getArticleDirectory,
@@ -12,6 +11,7 @@ import {
 } from "../../helpers";
 
 import { CrowdinArticleDirectory } from '../../../payload-types'
+import { PayloadRequest } from "payload/types";
 
 interface IcreateOrUpdateFile {
   name: string;
@@ -32,10 +32,10 @@ export class payloadCrowdinSyncFilesApi {
   uploadStorageApi: UploadStorage;
   projectId: number;
   directoryId?: number;
-  payload: Payload;
+  req: PayloadRequest;
   pluginOptions: PluginOptions;
 
-  constructor(pluginOptions: PluginOptions, payload: Payload) {
+  constructor(pluginOptions: PluginOptions, req: PayloadRequest) {
     // credentials
     const credentials: Credentials = {
       token: pluginOptions.token,
@@ -45,7 +45,7 @@ export class payloadCrowdinSyncFilesApi {
     this.directoryId = pluginOptions.directoryId;
     this.sourceFilesApi = sourceFilesApi;
     this.uploadStorageApi = uploadStorageApi;
-    this.payload = payload;
+    this.req = req;
     this.pluginOptions = pluginOptions;
   }
 
@@ -102,7 +102,7 @@ export class payloadCrowdinSyncFilesApi {
   }
 
   async getArticleDirectory(documentId: string): Promise<CrowdinArticleDirectory | undefined> {
-    const result = await getArticleDirectory(documentId, this.payload);
+    const result = await getArticleDirectory(documentId, this.req.payload);
     return result as CrowdinArticleDirectory | undefined;
   }
 
@@ -117,19 +117,20 @@ export class payloadCrowdinSyncFilesApi {
       this.projectId,
       crowdinPayloadArticleDirectory.originalId
     );
-    await this.payload.delete({
+    await this.req.payload.delete({
       collection: "crowdin-article-directories",
       id: crowdinPayloadArticleDirectory.id,
+      req: this.req,
     });
   }
 
   async getFileByDocumentID(name: string, documentId: string) {
-    const result = await getFileByDocumentID(name, documentId, this.payload);
+    const result = await getFileByDocumentID(name, documentId, this.req.payload);
     return result;
   }
 
   async getFilesByDocumentID(documentId: string) {
-    const result = await getFilesByDocumentID(documentId, this.payload);
+    const result = await getFilesByDocumentID(documentId, this.req.payload);
     return result;
   }
 }

--- a/plugin/src/lib/api/payload-crowdin-sync/translations.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/translations.ts
@@ -377,7 +377,7 @@ export class payloadCrowdinSyncTranslationsApi {
             // get translations here and pass it to convertHtmlToLexical
             // easier than passing `payload` and `pluginOptions` to create a new instance of the class we are in right now - keep convertHtmlToLexical focussed.
             const blockConfig = getLexicalBlockFields(editorConfig)
-            
+
             const blockTranslations = blockConfig ? await this.getBlockTranslations({
               blockConfig,
               file,
@@ -461,7 +461,7 @@ export class payloadCrowdinSyncTranslationsApi {
     const localizedHtmlFields = await this.getHtmlFieldSlugsByArticleDirectory(getRelationshipId(file.crowdinArticleDirectory));
     const crowdinHtmlObject: CrowdinHtmlObject = {};
     for (const field of localizedHtmlFields) {
-      // need to get the field definiton here somehow?
+      // need to get the field definition here somehow?
       crowdinHtmlObject[field] = await this.getTranslation({
         documentId: field,
         fieldName: field,

--- a/plugin/src/lib/hooks/collections/afterChange.ts
+++ b/plugin/src/lib/hooks/collections/afterChange.ts
@@ -176,7 +176,9 @@ const performAfterChange = async ({
         Object.keys(currentCrowdinJsonData).length !== 0) ||
       process.env['PAYLOAD_CROWDIN_SYNC_ALWAYS_UPDATE'] === "true"
     ) {
-      await filesApi.createOrUpdateJsonFile(currentCrowdinJsonData);
+      await filesApi.createOrUpdateJsonFile({
+        fileData: currentCrowdinJsonData
+      });
     }
   };
 

--- a/plugin/src/lib/hooks/collections/afterChange.ts
+++ b/plugin/src/lib/hooks/collections/afterChange.ts
@@ -163,7 +163,7 @@ const performAfterChange = async ({
       collectionSlug: collection.slug as keyof Config['collections'] | keyof Config['globals'],
       global,
       pluginOptions,
-      payload: req.payload
+      req: req
     },
   );
   const filesApi = await apiByDocument.get()

--- a/plugin/src/lib/hooks/collections/afterDelete.ts
+++ b/plugin/src/lib/hooks/collections/afterDelete.ts
@@ -35,7 +35,7 @@ export const getAfterDeleteHook =
         collectionSlug: collection.slug as keyof Config['collections'] | keyof Config['globals'],
         global,
         pluginOptions,
-        payload: req.payload
+        req: req
       },
     );
     const filesApi = await apiByDocument.get()

--- a/plugin/src/lib/utilities/lexical/index.ts
+++ b/plugin/src/lib/utilities/lexical/index.ts
@@ -18,8 +18,16 @@ export const getLexicalEditorConfig = (field: RichTextField) => {
   return undefined
 }
 
-export const getLexicalBlockFields = (editorConfig: SanitizedEditorConfig) => editorConfig.resolvedFeatureMap.get('blocks')?.props as {
+export const getLexicalBlockFields = (editorConfig: SanitizedEditorConfig): {
   blocks: Block[]
+} | undefined => {
+  const blocks = editorConfig.resolvedFeatureMap.get('blocks')
+  if (blocks) {
+    return blocks.props as {
+      blocks: Block[]
+    }
+  }
+  return undefined
 }
 
 export const extractLexicalBlockContent = (root: SerializedRootNode) => {


### PR DESCRIPTION
Add a test for updating a translation to dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts.

Includes a refactor to pass the `req` object rather than the `req.payload` object to the document/files internal apis. Although this was an unsuccessful attempt the ensure the `crowdinArticleDirectory` relationship was set on a newly created localized document, it is kept in here as it may be a positive step towards resolving https://github.com/thompsonsj/payload-crowdin-sync/issues/190.