### PR TITLE
feat(reviewtranslation): locale parameter

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -106,6 +106,16 @@ Your [Crowdin API token](https://support.crowdin.com/enterprise/personal-access-
 }
 ```
 
+### `organizationId` (required)
+
+Your [Crowdin organization ID](https://support.crowdin.com/enterprise/organization/).
+
+```js
+{
+  organizationId: 200000000
+}
+```
+
 ### `directoryId`
 
 Crowdin directory ID to store translations. To get the directory ID without making an API call, inspect the page source of your folder in [Sources > Files](https://support.crowdin.com/file-management/#branches-and-folders).
@@ -327,6 +337,7 @@ The document will be updated and the same report will be generated as for a revi
 ##### Notes
 
 - Pass the `draft=true` query parameter to update as a draft rather than a published version.
+- Pass a `locale` parameter to perform a review/update for one locale only. e.g. `locale=fr_FR`.
 - The source locale (e.g. `en`) is not affected.
 - Use the `excludeLocales` field on documents in the `crowdin-article-directories` collection to prevent some locales from being included in the review/update operation.
 - If supplied translations do not contain required fields, translation updates will not be applied and validation errors will be returned in the API response.

--- a/plugin/docs/crowdin.md
+++ b/plugin/docs/crowdin.md
@@ -70,6 +70,8 @@ Three new collections are created.
 
 For each document in a collection that contains localized fields, an additonal field is added: `crowdinArticleDirectory`. This is a one-to-one relationship with an article created in the `crowdin-article-directories` collection.
 
+To completely uninstall the plugin, delete the three collections and delete the `crowdinArticleDirectory` field from any of your localized documents as appropriate.
+
 ### `crowdin-collection-directories`
 
 Each entry in the `crowdin-article-directories` collection has a one-to-one relationship with an entry in the `crowdin-collection-directories` collection.

--- a/plugin/src/lib/endpoints/globals/reviewTranslation.ts
+++ b/plugin/src/lib/endpoints/globals/reviewTranslation.ts
@@ -12,12 +12,15 @@ export const getReviewTranslationEndpoint = ({
   path: `/:id/${type}`,
   method: "get",
   handler: async (req, res) => {
+    const locale = req.query['locale']
+    const excludeLocales = locale ? Object.keys(pluginOptions.localeMap || {}).filter(payloadLocale => payloadLocale !== locale) : undefined
     const update = await updatePayloadTranslation({
       articleDirectoryId: req.params['id'],
       pluginOptions,
       payload: req.payload,
       draft: req.query["draft"] === 'true' ? true : false,
       dryRun: type === "update" ? false : true,
+      excludeLocales,
     })
     
     res.status(update.status).send(update);


### PR DESCRIPTION
Add a `locale` parameter to use review/update endpoints for a specific locale only.