### PR TITLE
patch(api): reduce console.log volume

### DIFF
--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -208,7 +208,6 @@ export async function updatePayloadTranslation({
       {
         articleDirectoryId,
         pluginOptions,
-        payload,
         draft,
         dryRun,
         excludeLocales,

--- a/plugin/src/lib/api/payload-crowdin-sync/translations.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/translations.ts
@@ -460,7 +460,7 @@ export class payloadCrowdinSyncTranslationsApi {
           documentId,
           fieldName,
           locale,
-          collection,
+          collection: collection?.slug,
           parentCrowdinArticleDirectoryId,
           fields
         },


### PR DESCRIPTION
Avoid certain objects polluting the server logs with extraneous information.