### PR TITLE
fix(pluginfields): error in sync translations single locale logic

### DIFF
--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -2,6 +2,7 @@ import type { Field, TabsField } from "payload/types";
 import { updatePayloadTranslation } from "../api/helpers";
 import { PluginOptions } from "../types";
 import { DocumentCustomUIField } from "./documentUI";
+import { getOtherLocales } from "../utilities/locales";
 
 interface Args {
   fields: Field[];
@@ -51,11 +52,10 @@ export const pluginCollectionOrGlobalFields = ({
           if (siblingData["syncTranslations"] && siblingData["crowdinArticleDirectory"]) {
             // is this a draft?
             const draft = Boolean(siblingData["_status"] && siblingData["_status"] !== 'published')
-            const excludeLocales = Object.keys(pluginOptions.localeMap)
-            const thisLocaleIndex = req.locale && excludeLocales.indexOf(req.locale)
-            if (thisLocaleIndex) {
-              excludeLocales.splice(thisLocaleIndex, 1)
-            }
+            const excludeLocales = getOtherLocales({
+              locale: `${req.locale}`,
+              localeMap: pluginOptions.localeMap
+            })
             context['articleDirectoryId'] = typeof siblingData["crowdinArticleDirectory"] === 'string' ? siblingData["crowdinArticleDirectory"] : siblingData["crowdinArticleDirectory"].id
             context['draft'] = draft
             context['excludeLocales'] = excludeLocales

--- a/plugin/src/lib/utilities/locales.spec.ts
+++ b/plugin/src/lib/utilities/locales.spec.ts
@@ -26,6 +26,10 @@ describe('fn: getOtherLocales', () => {
       'fr_FR',
       ['da_DK', 'de_DE']
     ],
+    [
+      '',
+      ['da_DK', 'de_DE', 'fr_FR']
+    ],
   ]
   describe.each(fixtures)(`%s`, (string, result) => {
     it(`${string} is excluded in returned locales`, () => {
@@ -34,5 +38,5 @@ describe('fn: getOtherLocales', () => {
           localeMap
       })).toEqual(result)
     });
+  });
 });
-})

--- a/plugin/src/lib/utilities/locales.spec.ts
+++ b/plugin/src/lib/utilities/locales.spec.ts
@@ -1,0 +1,38 @@
+import { getOtherLocales } from './locales'
+
+const localeMap = {
+  da_DK: {
+    crowdinId: "da",
+  },
+  de_DE: {
+    crowdinId: "de",
+  },
+  fr_FR: {
+    crowdinId: "fr",
+  },
+};
+
+describe('fn: getOtherLocales', () => {
+  const fixtures = [
+    [
+      'da_DK',
+      ['de_DE', 'fr_FR']
+    ],
+    [
+      'de_DE',
+      ['da_DK', 'fr_FR']
+    ],
+    [
+      'fr_FR',
+      ['da_DK', 'de_DE']
+    ],
+  ]
+  describe.each(fixtures)(`%s`, (string, result) => {
+    it(`${string} is excluded in returned locales`, () => {
+        expect(getOtherLocales({
+          locale: string as string,
+          localeMap
+      })).toEqual(result)
+    });
+});
+})

--- a/plugin/src/lib/utilities/locales.ts
+++ b/plugin/src/lib/utilities/locales.ts
@@ -8,8 +8,8 @@ export const getOtherLocales = ({
   localeMap: PluginOptions['localeMap']
 }) => {
   const excludeLocales = Object.keys(localeMap)
-  const thisLocaleIndex = locale && excludeLocales.indexOf(locale)
-  if (thisLocaleIndex) {
+  const thisLocaleIndex = locale ? excludeLocales.indexOf(locale) : -1
+  if (thisLocaleIndex !== -1) {
     excludeLocales.splice(thisLocaleIndex, 1)
   }
   return excludeLocales

--- a/plugin/src/lib/utilities/locales.ts
+++ b/plugin/src/lib/utilities/locales.ts
@@ -1,0 +1,16 @@
+import { PluginOptions } from "../types"
+
+export const getOtherLocales = ({
+  locale,
+  localeMap,
+}: {
+  locale: string,
+  localeMap: PluginOptions['localeMap']
+}) => {
+  const excludeLocales = Object.keys(localeMap)
+  const thisLocaleIndex = locale && excludeLocales.indexOf(locale)
+  if (thisLocaleIndex) {
+    excludeLocales.splice(thisLocaleIndex, 1)
+  }
+  return excludeLocales
+}


### PR DESCRIPTION
The first locale in `localeMap` can never be used with `syncTranslations`. This is due to an oversight in the logic for calculating all the locales to exclude.

We use `indexOf` to see if a locale is in `localeMap`. If it is the first locale, `indexOf` returns 0. A truthy condition is then run on this result, meaning 0 returns false.

Fix this logic. Extract to a function and add tests.