### PR TITLE
feat(crowdinfiles): delete document if Crowdin API returns 404

### DIFF
--- a/dev/src/lib/tests/collections/localized-posts-delete-404-files.test.ts
+++ b/dev/src/lib/tests/collections/localized-posts-delete-404-files.test.ts
@@ -1,0 +1,98 @@
+import payload from 'payload';
+import { initPayloadTest } from '../helpers/config';
+import nock from 'nock';
+import { mockCrowdinClient } from 'plugin/src/lib/api/mock/crowdin-api-responses';
+import { pluginConfig } from '../helpers/plugin-config';
+import { getFilesByDocumentID, payloadCrowdinSyncTranslationsApi } from 'payload-crowdin-sync';
+
+const pluginOptions = pluginConfig();
+const mockClient = mockCrowdinClient(pluginOptions);
+
+describe('Lexical editor with multiple blocks', () => {
+  beforeAll(async () => {
+    await initPayloadTest({});
+  });
+
+  afterEach((done) => {
+    if (!nock.isDone()) {
+      throw new Error(
+        `Not all nock interceptors were used: ${JSON.stringify(
+          nock.pendingMocks()
+        )}`
+      );
+    }
+    nock.cleanAll();
+    done();
+  });
+
+  afterAll(async () => {
+    if (typeof payload?.db?.destroy === 'function') {
+      await payload.db.destroy(payload);
+    }
+  });
+
+  it('removes CrowdinFile Payload documents if the Crowdin API responds with a 404', async () => {
+    nock('https://api.crowdin.com')
+    .post(
+      `/api/v2/projects/${pluginOptions.projectId}/directories`
+    )
+    .twice()
+    .reply(200, mockClient.createDirectory({}))
+    .post(
+      `/api/v2/storages`
+    )
+    .reply(200, mockClient.addStorage())
+    .post(
+      `/api/v2/projects/${pluginOptions.projectId}/files`
+    )
+    .reply(
+      200,
+      mockClient.createFile({
+        fileId: 94100,
+      })
+    )
+    // translation
+    .post(
+      `/api/v2/projects/${
+        pluginOptions.projectId
+      }/translations/builds/files/${94100}`,
+      {
+        targetLanguageId: 'fr',
+      }
+    )
+    .reply(
+      404,
+      {
+        code: 404,
+      }
+    )
+    
+    const post = await payload.create({
+      collection: "localized-posts-with-condition",
+      data: {
+        title: "Test post",
+        translateWithCrowdin: true,
+      },
+    });
+
+    const crowdinFiles = await getFilesByDocumentID(`${post.id}`, payload);
+
+    expect(crowdinFiles.length).toEqual(1)
+
+    const translationsApi = new payloadCrowdinSyncTranslationsApi(
+      pluginOptions,
+      payload
+    );
+
+    await translationsApi.updateTranslation({
+      documentId: `${post.id}`,
+      collection: 'localized-posts-with-condition',
+      dryRun: false,
+      excludeLocales: ['de_DE'],
+    });
+
+    const refreshedCrowdinFiles = await getFilesByDocumentID(`${post.id}`, payload);
+
+    expect(refreshedCrowdinFiles.length).toEqual(0)
+  });
+});

--- a/dev/src/lib/tests/collections/localized-posts-with-condition.test.ts
+++ b/dev/src/lib/tests/collections/localized-posts-with-condition.test.ts
@@ -62,7 +62,7 @@ describe("Collection: Localized Posts With Conditon", () => {
       expect(Object.prototype.hasOwnProperty.call(result, 'crowdinArticleDirectory')).toBeFalsy();
     });
 
-    it("creates an article directory if the conditon is met", async () => {
+    it("creates an article directory if the condition is met", async () => {
       nock('https://api.crowdin.com')
         .post(
           `/api/v2/projects/${pluginOptions.projectId}/directories`

--- a/plugin/src/lib/api/payload-crowdin-sync/files/by-document.ts
+++ b/plugin/src/lib/api/payload-crowdin-sync/files/by-document.ts
@@ -29,7 +29,7 @@ export class filesApiByDocument {
   directoryId?: number;
   document: Document
   articleDirectory: CrowdinArticleDirectory
-  collectionSlug: keyof Config['collections'] | "globals";
+  collectionSlug: keyof Config['collections'] | keyof Config['globals'];
   global: boolean;
   pluginOptions: PluginOptions;
   req: PayloadRequest;
@@ -44,7 +44,7 @@ export class filesApiByDocument {
     parent,
   }: {
     document: Document,
-    collectionSlug:  keyof Config['collections'] | "globals",
+    collectionSlug: keyof Config['collections'] | keyof Config['globals'],
     global: boolean,
     pluginOptions: PluginOptions,
     req: PayloadRequest,

--- a/plugin/src/lib/plugin.ts
+++ b/plugin/src/lib/plugin.ts
@@ -100,6 +100,8 @@ export const crowdinSync =
       pluginCollectionAdmin: Joi.object(),
       tabbedUI: Joi.boolean(),
       lexicalBlockFolderPrefix: Joi.string(),
+      /** Prevent the plugin deleting Payload documents it has created in response to Crowdin API responses. */
+      disableSelfClean: Joi.boolean(),
     });
 
     const validate = schema.validate(pluginOptions);

--- a/plugin/src/lib/types.ts
+++ b/plugin/src/lib/types.ts
@@ -45,6 +45,7 @@ export interface PluginOptions {
   pluginCollectionAdmin?: CollectionConfig["admin"];
   tabbedUI?: boolean
   lexicalBlockFolderPrefix?: string
+  disableSelfClean?: boolean
 }
 
 export type FieldWithName = Field & { name: string };


### PR DESCRIPTION
After https://github.com/thompsonsj/payload-crowdin-sync/pull/206, it's clear that in the scenario where files are deleted on Crowdin, plugin translation operations are slowed down as it attempts to retrieve deleted files receiving a 404 response from the Crowdin API for each one.

```
error CrowdinError: File Not Found
    at handleHttpClientError (/<app-dir>/node_modules/@crowdin/crowdin-api-client/out/core/index.js:82:15)
    at /<app-dir>/node_modules/@crowdin/crowdin-api-client/out/core/index.js:254:29
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  code: 404
}
```

Delete the `CrowdinFiles` document if the Crowdin API indicates that the file does not exist. Include a flag in config to disable this behaviour in case things start going wrong (also a useful flag anyway in case  users of the plugin prefer to keep a record of all Crowdin files created)!

Includes some type fixes.