### PR TITLE
fix(translations): faulty logic to lookup lexical block files

### DIFF
--- a/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
+++ b/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
@@ -938,8 +938,6 @@ describe('Lexical editor with multiple blocks', () => {
           targetLanguageId: 'fr',
         }
       )
-      // TODO: figure out why twice?
-      .twice()
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
@@ -953,8 +951,6 @@ describe('Lexical editor with multiple blocks', () => {
           pluginOptions.projectId
         }/translations/builds/${48313}/download`
       )
-      // TODO: figure out why twice?
-      .twice()
       .query({
         targetLanguageId: 'fr',
       })
@@ -978,8 +974,6 @@ describe('Lexical editor with multiple blocks', () => {
           targetLanguageId: 'fr',
         }
       )
-      // TODO: figure out why twice?
-      .twice()
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
@@ -993,8 +987,6 @@ describe('Lexical editor with multiple blocks', () => {
           pluginOptions.projectId
         }/translations/builds/${48314}/download`
       )
-      // TODO: figure out why twice?
-      .twice()
       .query({
         targetLanguageId: 'fr',
       })

--- a/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
+++ b/dev/src/lib/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
@@ -13,7 +13,8 @@ import {
 } from '../../payload-types';
 import {
   getFilesByDocumentID,
-  getFilesByParent,
+  getFiles,
+  getLexicalFieldArticleDirectory,
 } from 'plugin/src/lib/api/helpers';
 import { getRelationshipId } from 'plugin/src/lib/utilities/payload';
 
@@ -752,8 +753,21 @@ describe('Lexical editor with multiple blocks', () => {
       },
     })) as any;
 
-    const files = await getFilesByParent(
-      `${getRelationshipId(doc.crowdinArticleDirectory)}`,
+    const arrayIds =
+      (doc.items || []).map((item) => item.id) || ([] as string[]);
+    const blockIds =
+      (doc.items || []).map(
+        (item) => (item.block || []).find((x) => x !== undefined)?.id
+      ) || ([] as string[]);
+
+    const lexicalFieldCrowdinArticleDirectory = await getLexicalFieldArticleDirectory({
+      payload,
+      parent: doc.crowdinArticleDirectory,
+      name: `lex.items.${arrayIds[1]}.block.${blockIds[1]}.basicBlockLexical.content`
+    })
+
+    const files = await getFiles(
+      `${getRelationshipId(lexicalFieldCrowdinArticleDirectory)}`,
       payload
     );
 
@@ -1025,9 +1039,14 @@ describe('Lexical editor with multiple blocks', () => {
       );
 
     const crowdinFiles = await getFilesByDocumentID(`${doc.id}`, payload);
-    const contentCrowdinFiles = await getFilesByParent(
-      `${getRelationshipId(updatedDoc.crowdinArticleDirectory)}`,
-      payload
+    const lexicalFieldCrowdinArticleDirectory = await getLexicalFieldArticleDirectory({
+      payload,
+      parent: updatedDoc.crowdinArticleDirectory,
+      name: `lex.items.${arrayIds[1]}.block.${blockIds[1]}.basicBlockLexical.content`
+    })
+    const contentCrowdinFiles = await getFiles(
+      `${getRelationshipId(lexicalFieldCrowdinArticleDirectory)}`,
+      payload 
     );
 
     // check file ids are always mapped in the same way

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -88,23 +88,12 @@ export async function getFileByParent(
   parentCrowdinArticleDirectoryId: string,
   payload: Payload
 ): Promise<any> {
-  const dirResult = await payload.find({
-    collection: "crowdin-article-directories",
-    where: {
-      parent: {
-        equals: parentCrowdinArticleDirectoryId,
-      },
-    },
-  });
-  const crowdinArticleDirectory = dirResult.docs[0]
-  const crowdinArticleDirectoryId = getRelationshipId(crowdinArticleDirectory as any)
-
   const result = await payload.find({
     collection: "crowdin-files",
     where: {
       field: { equals: name },
       crowdinArticleDirectory: {
-        equals: crowdinArticleDirectoryId,
+        equals: parentCrowdinArticleDirectoryId,
       },
     },
   });

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -66,6 +66,25 @@ export async function getArticleDirectory(
     : undefined;
 }
 
+export async function getLexicalFieldArticleDirectory({
+  payload,
+  parent,
+  name,
+}: {
+  payload: Payload,
+  parent?: CrowdinArticleDirectory | null | string,
+  name: string,
+}) {
+  const dir = await getArticleDirectory(
+    /** 'document id' is the field name in dot notation for lexical blocks */
+    name,
+    payload,
+    false,
+    parent,
+  ) as any
+  return dir as CrowdinArticleDirectory
+}
+
 export async function getFile(
   name: string,
   crowdinArticleDirectoryId: string,
@@ -83,55 +102,10 @@ export async function getFile(
   return result.docs[0];
 }
 
-export async function getFileByParent(
-  name: string,
-  parentCrowdinArticleDirectoryId: string,
-  payload: Payload
-): Promise<any> {
-  const result = await payload.find({
-    collection: "crowdin-files",
-    where: {
-      field: { equals: name },
-      crowdinArticleDirectory: {
-        equals: parentCrowdinArticleDirectoryId,
-      },
-    },
-  });
-
-  return result.docs[0];
-}
-
 export async function getFiles(
   crowdinArticleDirectoryId: string,
   payload: Payload
-): Promise<any> {
-  const result = await payload.find({
-    collection: "crowdin-files",
-    limit: 10000,
-    where: {
-      crowdinArticleDirectory: {
-        equals: crowdinArticleDirectoryId,
-      },
-    },
-  });
-  return result.docs;
-}
-
-export async function getFilesByParent(
-  parentCrowdinArticleDirectoryId: string,
-  payload: Payload
 ): Promise<CrowdinFile[]> {
-  const dirResult = await payload.find({
-    collection: "crowdin-article-directories",
-    where: {
-      parent: {
-        equals: parentCrowdinArticleDirectoryId,
-      },
-    },
-  });
-  const crowdinArticleDirectory = dirResult.docs[0]
-  const crowdinArticleDirectoryId = getRelationshipId(crowdinArticleDirectory as any)
-
   const result = await payload.find({
     collection: "crowdin-files",
     limit: 10000,


### PR DESCRIPTION
Lexical block files were retrieved in a faulty way based on the current article directory's parent article directory.

Fix this logic to lookup the article directory that was created specifically for the Lexical field in question.

This reduces API calls to the number that we expect.

Note: I recognise the confusing description! Hard to recognise what was going on exactly. The main outcome is that tests make sense and the APIs like `translations` and `files` need to be refactored - they can be broken down into smaller functions.

Effort has been made to remove unnecessary functions and rename variables in order to facilitate any future refactor work.