### PR TITLE
fix(package.json): payload dependencies as peer

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -20,6 +20,10 @@
   },
   "peerDependencies": {
     "payload": "^3",
+    "@payloadcms/db-mongodb": "^3",
+    "@payloadcms/richtext-lexical": "^3",
+    "@payloadcms/richtext-slate": "^3",
+    "@payloadcms/ui": "^3",
     "react": "^19.0.0"
   },
   "type": "module"


### PR DESCRIPTION
Avoid errors such as the following in your Payload installation.

```
unhandledRejection: [Error: Mismatching "payload" dependency versions found: @payloadcms/richtext-lexical@3.15.1 (Please change this to 3.14.0). All "payload" packages must have the same version. This is an error with your set-up, not a bug in Payload. Please go to your package.json and ensure all "payload" packages have the same version.]
```