### PR TITLE
test(translations): restore

### DIFF
--- a/dev/src/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
+++ b/dev/src/tests/collections/lexical-editor-with-blocks-inside-array.test.ts
@@ -945,7 +945,6 @@ describe('Lexical editor with multiple blocks', () => {
     `);
   });
 
-  /**
   it('updates the Payload document with a translation from Crowdin', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
@@ -1321,6 +1320,8 @@ describe('Lexical editor with multiple blocks', () => {
                       "direction": "ltr",
                       "format": "",
                       "indent": 0,
+                      "textFormat": 0,
+                      "textStyle": "",
                       "type": "paragraph",
                       "version": 1,
                     },
@@ -1360,6 +1361,8 @@ describe('Lexical editor with multiple blocks', () => {
                       "direction": "ltr",
                       "format": "",
                       "indent": 0,
+                      "textFormat": 0,
+                      "textStyle": "",
                       "type": "paragraph",
                       "version": 1,
                     },
@@ -1472,6 +1475,8 @@ describe('Lexical editor with multiple blocks', () => {
                                 "direction": "ltr",
                                 "format": "",
                                 "indent": 0,
+                                "textFormat": 0,
+                                "textStyle": "",
                                 "type": "paragraph",
                                 "version": 1,
                               },
@@ -1509,5 +1514,4 @@ describe('Lexical editor with multiple blocks', () => {
       ]
     );
   });
-   */
 });

--- a/dev/src/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -800,7 +800,6 @@ describe('Lexical editor with multiple blocks', () => {
     )
   })
 
-  /**
   it('updates a Payload article with a rich text field that uses the Lexical editor with multiple blocks with a translation received from Crowdin', async () => {
     nock('https://api.crowdin.com')
       .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
@@ -815,7 +814,7 @@ describe('Lexical editor with multiple blocks', () => {
         200,
         mockClient.createFile({
           fileId: 56641,
-        })
+        }),
       )
       // file 2 creation
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
@@ -823,7 +822,7 @@ describe('Lexical editor with multiple blocks', () => {
         200,
         mockClient.createFile({
           fileId: 56642,
-        })
+        }),
       )
       // file 3 creation
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
@@ -831,7 +830,7 @@ describe('Lexical editor with multiple blocks', () => {
         200,
         mockClient.createFile({
           fileId: 56643,
-        })
+        }),
       )
       // file 4 creation
       .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
@@ -839,82 +838,55 @@ describe('Lexical editor with multiple blocks', () => {
         200,
         mockClient.createFile({
           fileId: 56644,
-        })
+        }),
       )
       // de - file 1 get translation
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56641}`,
-        {
-          targetLanguageId: 'de',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56641}`, {
+        targetLanguageId: 'de',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56641}/download?targetLanguageId=de`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56641}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56641}/download`)
       .query({
         targetLanguageId: 'de',
       })
       .reply(200, {})
       // de - file 4 get translation
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56644}`,
-        {
-          targetLanguageId: 'de',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56644}`, {
+        targetLanguageId: 'de',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56644}/download?targetLanguageId=de`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56644}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56644}/download`)
       .query({
         targetLanguageId: 'de',
       })
       .reply(200, {})
       // de - file 2 get translation
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56642}`,
-        {
-          targetLanguageId: 'de',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56642}`, {
+        targetLanguageId: 'de',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56642}/download?targetLanguageId=de`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56642}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download`)
       .query({
         targetLanguageId: 'de',
       })
@@ -942,82 +914,55 @@ describe('Lexical editor with multiple blocks', () => {
         },
       })
       // de - file 3 get translation
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56643}`,
-        {
-          targetLanguageId: 'de',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56643}`, {
+        targetLanguageId: 'de',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56643}/download?targetLanguageId=de`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56643}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56643}/download`)
       .query({
         targetLanguageId: 'de',
       })
       .reply(
         200,
-        '<p>Das Plugin analysiert Ihre Blockkonfiguration für den Lexical-Rich-Text-Editor. Es extrahiert alle Blockwerte aus dem Rich-Text-Feld und behandelt diese Konfigurations-/Datenkombination dann als reguläres „Blocks“-Feld.</p<p>>Im HTML werden Markierungen platziert und dieser Inhalt wird bei der Übersetzung an der richtigen Stelle wiederhergestellt.</p>'
+        '<p>Das Plugin analysiert Ihre Blockkonfiguration für den Lexical-Rich-Text-Editor. Es extrahiert alle Blockwerte aus dem Rich-Text-Feld und behandelt diese Konfigurations-/Datenkombination dann als reguläres „Blocks“-Feld.</p<p>>Im HTML werden Markierungen platziert und dieser Inhalt wird bei der Übersetzung an der richtigen Stelle wiederhergestellt.</p>',
       )
       // fr - file 1 get translation
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56641}`,
-        {
-          targetLanguageId: 'fr',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56641}`, {
+        targetLanguageId: 'fr',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56641}/download?targetLanguageId=fr`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56641}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56641}/download`)
       .query({
         targetLanguageId: 'fr',
       })
       .reply(200, {})
       // fr - file 2 get translation
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56642}`,
-        {
-          targetLanguageId: 'fr',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56642}`, {
+        targetLanguageId: 'fr',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56642}/download?targetLanguageId=fr`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56642}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56642}/download`)
       .query({
         targetLanguageId: 'fr',
       })
@@ -1035,8 +980,7 @@ describe('Lexical editor with multiple blocks', () => {
             highlight: {
               heading: {
                 title: 'Les blocs sont extraits dans leurs propres champs',
-                preTitle:
-                  "Comment le plugin gère les blocs dans l'éditeur lexical",
+                preTitle: "Comment le plugin gère les blocs dans l'éditeur lexical",
               },
             },
           },
@@ -1049,65 +993,47 @@ describe('Lexical editor with multiple blocks', () => {
       })
       // fr - file 3 get translation
 
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56643}`,
-        {
-          targetLanguageId: 'fr',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56643}`, {
+        targetLanguageId: 'fr',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56643}/download?targetLanguageId=fr`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56643}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56643}/download`)
       .query({
         targetLanguageId: 'fr',
       })
       .reply(
         200,
-        "<p>Le plugin analyse la configuration de votre bloc pour l'éditeur de texte enrichi lexical. Il extrait toutes les valeurs de bloc du champ de texte enrichi, puis traite cette combinaison configuration/données comme un champ « blocs » normal.</p<p>>Les marqueurs sont placés dans le code HTML et ce contenu est restauré au bon endroit lors de la traduction.</p>"
+        "<p>Le plugin analyse la configuration de votre bloc pour l'éditeur de texte enrichi lexical. Il extrait toutes les valeurs de bloc du champ de texte enrichi, puis traite cette combinaison configuration/données comme un champ « blocs » normal.</p<p>>Les marqueurs sont placés dans le code HTML et ce contenu est restauré au bon endroit lors de la traduction.</p>",
       )
 
       // fr - file 4 get translation
-      .post(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/files/${56644}`,
-        {
-          targetLanguageId: 'fr',
-        }
-      )
+      .post(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${56644}`, {
+        targetLanguageId: 'fr',
+      })
       .reply(
         200,
         mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${
             pluginOptions.projectId
           }/translations/builds/${56644}/download?targetLanguageId=fr`,
-        })
+        }),
       )
-      .get(
-        `/api/v2/projects/${
-          pluginOptions.projectId
-        }/translations/builds/${56644}/download`
-      )
+      .get(`/api/v2/projects/${pluginOptions.projectId}/translations/builds/${56644}/download`)
       .query({
         targetLanguageId: 'fr',
       })
       .reply(
         200,
         `<p>Exemple de contenu pour un champ de texte enrichi lexical avec plusieurs blocs.</p><span data-block-id=65d67d2591c92e447e7472f7 data-block-type=cta></span><p>Une liste à puces entre certains blocs composée de:</p><ul class="bullet"><li value=1>un élément de liste à puces ; et</li><li value=2>
-      un autre!</li></ul><span data-block-id=65d67d8191c92e447e7472f8 data-block-type=highlight></span><span data-block-id=65d67e2291c92e447e7472f9 data-block-type=imageText></span><ul class="bullet"><li value=1></li></ul>`
-      );
+      un autre!</li></ul><span data-block-id=65d67d8191c92e447e7472f8 data-block-type=highlight></span><span data-block-id=65d67e2291c92e447e7472f9 data-block-type=imageText></span><ul class="bullet"><li value=1></li></ul>`,
+      )
 
     const policy = await payload.create({
       collection: 'policies',
@@ -1115,23 +1041,23 @@ describe('Lexical editor with multiple blocks', () => {
         title: 'Test policy',
         content: fixture,
       },
-    });
-    const crowdinFiles = await getFilesByDocumentID({documentId: `${policy.id}`, payload});
+    })
+    const crowdinFiles = await getFilesByDocumentID({ documentId: `${policy.id}`, payload })
     const contentCrowdinFiles = await getFilesByDocumentID({
       documentId: `${pluginOptions.lexicalBlockFolderPrefix}content`,
       payload,
-      parent: policy['crowdinArticleDirectory'] as CrowdinArticleDirectory
-    });
+      parent: policy['crowdinArticleDirectory'] as CrowdinArticleDirectory,
+    })
 
     // check file ids are always mapped in the same way
     const fileIds = crowdinFiles.map((file) => ({
       fileId: file.originalId,
       field: file.field,
-    }));
+    }))
     const contentFileIds = contentCrowdinFiles.map((file) => ({
       fileId: file.originalId,
       field: file.field,
-    }));
+    }))
     expect(fileIds).toEqual([
       {
         field: 'content',
@@ -1141,7 +1067,7 @@ describe('Lexical editor with multiple blocks', () => {
         field: 'fields',
         fileId: 56641,
       },
-    ]);
+    ])
     expect(contentFileIds).toEqual([
       {
         field: `blocks.65d67d8191c92e447e7472f8.highlight.content`,
@@ -1151,22 +1077,19 @@ describe('Lexical editor with multiple blocks', () => {
         field: 'blocks',
         fileId: 56642,
       },
-    ]);
-    const translationsApi = new payloadCrowdinSyncTranslationsApi(
-      pluginOptions,
-      payload
-    );
+    ])
+    const translationsApi = new payloadCrowdinSyncTranslationsApi(pluginOptions, payload)
     await translationsApi.updateTranslation({
       documentId: `${policy.id}`,
       collection: 'policies',
       dryRun: false,
-    });
+    })
     // retrieve translated post from Payload
     const result = await payload.findByID({
       collection: 'policies',
       id: `${policy.id}`,
       locale: 'fr_FR',
-    });
+    })
     expect(result['content']).toMatchInlineSnapshot(`
       {
         "root": {
@@ -1186,6 +1109,8 @@ describe('Lexical editor with multiple blocks', () => {
               "direction": "ltr",
               "format": "",
               "indent": 0,
+              "textFormat": 0,
+              "textStyle": "",
               "type": "paragraph",
               "version": 1,
             },
@@ -1218,6 +1143,8 @@ describe('Lexical editor with multiple blocks', () => {
               "direction": "ltr",
               "format": "",
               "indent": 0,
+              "textFormat": 0,
+              "textStyle": "",
               "type": "paragraph",
               "version": 1,
             },
@@ -1293,6 +1220,8 @@ describe('Lexical editor with multiple blocks', () => {
                         "direction": "ltr",
                         "format": "",
                         "indent": 0,
+                        "textFormat": 0,
+                        "textStyle": "",
                         "type": "paragraph",
                         "version": 1,
                       },
@@ -1364,7 +1293,6 @@ describe('Lexical editor with multiple blocks', () => {
           "version": 1,
         },
       }
-    `);
-  });
-  */
+    `)
+  })
 })

--- a/dev/src/tests/translations/send/translations.test.ts
+++ b/dev/src/tests/translations/send/translations.test.ts
@@ -77,6 +77,22 @@ describe("Translations", () => {
         .reply(200, mockClient.buildProjectFileTranslation({
           url: `https://api.crowdin.com/api/v2/projects/${pluginOptions.projectId}/translations/builds/${fileId}/download?targetLanguageId=de`
         }))
+        // /api/v2/projects/323731/translations/builds/344/download
+        // https://api.crowdin.com/api/v2/projects/323731/translations/builds/344/download?targetLanguageId=de
+        //  Not all nock interceptors were used: ["GET https://api.crowdin.com:443/api/v2/projects/323731/translations/builds/344/download"]
+        // fixed by using nock@beta that introduces experimental support for fetch (used in getFileDataFromUrl in our translations API)
+        // example nock response from fetch:
+        // Response {
+        //  status: 200,
+        //  statusText: 'OK',
+        //  headers: Headers { 'Content-Type': 'application/json' },
+        //  body: ReadableStream { locked: false, state: 'readable', supportsBYOB: false },
+        //  bodyUsed: false,
+        //  ok: true,
+        //  redirected: false,
+        //  type: 'default',
+        //  url: 'https://api.crowdin.com/api/v2/projects/323731/translations/builds/344/download?targetLanguageId=de'
+        //}
         .get(
           `/api/v2/projects/${pluginOptions.projectId}/translations/builds/${fileId}/download`
         )
@@ -86,7 +102,7 @@ describe("Translations", () => {
         .reply(200, {
           title: "Testbeitrag",
         })
-
+        
       const post = await payload.create({
         collection: "localized-posts",
         data: { title: "Test post" },
@@ -1101,12 +1117,6 @@ describe("Translations", () => {
         collection: slug,
         data,
       });
-      /**
-      const result = await payload.findByID({
-        collection: slug,
-        id: `${post.id}`,
-      });
-      */
       const translationsApi = new payloadCrowdinSyncTranslationsApi(
         pluginOptions,
         payload

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "jest": "29.7.0",
         "jest-environment-node": "^29.7.0",
         "mongodb-memory-server": "^10.1.3",
-        "nock": "13.5.6",
+        "nock": "^14.0.0-beta.19",
         "nodemailer": "^6.9.16",
         "nodemon": "^3.1.9",
         "nx": "20.3.1",
@@ -2338,6 +2338,20 @@
         "stylis": "4.2.0"
       }
     },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
@@ -4211,6 +4225,24 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.37.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
+      "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -4993,6 +5025,31 @@
         "yargs-parser": "21.1.1"
       }
     },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@oxc-resolver/binding-darwin-arm64": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-1.12.0.tgz",
@@ -5165,6 +5222,126 @@
       },
       "peerDependencies": {
         "payload": "3.15.1"
+      }
+    },
+    "node_modules/@payloadcms/graphql": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@payloadcms/graphql/-/graphql-3.15.1.tgz",
+      "integrity": "sha512-fU4xScCBZl8ASBPOfNzcrguQ6UsdgSOdo+aDFCh1YQ4yAqcGkAusulwWYsPKwuaWgxqizttlkFTg7cNSMN7w+w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graphql-scalars": "1.22.2",
+        "pluralize": "8.0.0",
+        "ts-essentials": "10.0.3",
+        "tsx": "4.19.2"
+      },
+      "bin": {
+        "payload-graphql": "bin.js"
+      },
+      "peerDependencies": {
+        "graphql": "^16.8.1",
+        "payload": "3.15.1"
+      }
+    },
+    "node_modules/@payloadcms/next": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@payloadcms/next/-/next-3.15.1.tgz",
+      "integrity": "sha512-PDcBIbfdt9EzbcghEhQuefwYNIWNnosnm5uGYFM3DVVrRGBRNSOC1PRwxkFIt8CxZ+sePGepGGwU6XppVvoPnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/core": "6.0.8",
+        "@payloadcms/graphql": "3.15.1",
+        "@payloadcms/translations": "3.15.1",
+        "@payloadcms/ui": "3.15.1",
+        "busboy": "^1.6.0",
+        "file-type": "19.3.0",
+        "graphql-http": "^1.22.0",
+        "graphql-playground-html": "1.6.30",
+        "http-status": "1.6.2",
+        "path-to-regexp": "^6.2.1",
+        "qs-esm": "7.0.2",
+        "react-diff-viewer-continued": "3.2.6",
+        "sass": "1.77.4",
+        "sonner": "^1.7.0",
+        "uuid": "10.0.0"
+      },
+      "engines": {
+        "node": "^18.20.2 || >=20.9.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.8.1",
+        "next": "^15.0.0",
+        "payload": "3.15.1"
+      }
+    },
+    "node_modules/@payloadcms/next/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@payloadcms/next/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@payloadcms/next/node_modules/react-diff-viewer-continued": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/react-diff-viewer-continued/-/react-diff-viewer-continued-3.2.6.tgz",
+      "integrity": "sha512-GrzyqQnjIMoej+jMjWvtVSsQqhXgzEGqpXlJ2dAGfOk7Q26qcm8Gu6xtI430PBUyZsERe8BJSQf+7VZZo8IBNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/css": "^11.10.5",
+        "classnames": "^2.3.1",
+        "diff": "^5.1.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@payloadcms/next/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@payloadcms/next/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@payloadcms/richtext-lexical": {
@@ -6343,7 +6520,6 @@
       "version": "19.0.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.4.tgz",
       "integrity": "sha512-3O4QisJDYr1uTUMZHA2YswiQZRq+Pd8D+GdVFYikTutYsTz+QZgWkAPnP7rx9txoI6EXKcPiluMqWPFV3tT9Wg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -8258,7 +8434,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -8881,7 +9056,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8995,7 +9169,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -9355,7 +9528,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -9380,7 +9552,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9411,6 +9582,13 @@
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -10072,6 +10250,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -12172,7 +12357,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -12823,6 +13007,48 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-http": {
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.3.tgz",
+      "integrity": "sha512-sgUz/2DZt+QvY6WrpAsAXUvhnIkp2eX9jN78V8DAtFcpZi/nfDrzDt2byYjyoJzRcWuqhE0K63g1QMewt73U6A==",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
+    "node_modules/graphql-playground-html": {
+      "version": "1.6.30",
+      "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.30.tgz",
+      "integrity": "sha512-tpCujhsJMva4aqE8ULnF7/l3xw4sNRZcSHu+R00VV+W0mfp+Q20Plvcrp+5UXD+2yS6oyCXncA+zoQJQqhGCEw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "xss": "^1.0.6"
+      }
+    },
+    "node_modules/graphql-scalars": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.22.2.tgz",
+      "integrity": "sha512-my9FB4GtghqXqi/lWSVAOPiTzTnnEzdOXCsAC2bb5V7EFNQjVjwy3cSSbUvgYOtDuDibd+ZsCDhz+4eykYOlhQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/gunzip-maybe": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
@@ -13215,6 +13441,13 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -13363,7 +13596,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jsbn": "1.1.0",
@@ -13377,14 +13610,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ipaddr.js": {
@@ -13498,7 +13731,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -13770,11 +14002,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -14047,6 +14285,17 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -14247,6 +14496,43 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jest-circus/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest-circus/node_modules/dedent": {
@@ -15226,6 +15512,28 @@
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.20.0.tgz",
       "integrity": "sha512-lJEHLFACXqRf3u/VlIOu9T7MJ51O4la92uOBwiS9Sx+juDK3Nrru5Vgl1aUirV1qK8XEM3h6Org2HcrsrzZ3ZA==",
       "license": "MIT"
+    },
+    "node_modules/lib0": {
+      "version": "0.2.99",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
+      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "2.0.3",
@@ -16283,6 +16591,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/mongodb": {
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
@@ -16715,18 +17030,18 @@
       }
     },
     "node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "version": "14.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.19.tgz",
+      "integrity": "sha512-xqWQQZ/Hv01tj5uL7BE4j752hhB2MHP7aaEcTp/iDT1EHsh3TYZOIx4HHFL81yRc8KFx4pqb2P2OtuxKShKhjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.37.3",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">= 18"
       }
     },
     "node_modules/node-fetch": {
@@ -16886,7 +17201,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17385,6 +17699,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -17591,6 +17912,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -17708,7 +18036,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -18403,7 +18730,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -18844,6 +19170,24 @@
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.77.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.4.tgz",
+      "integrity": "sha512-vcF3Ckow6g939GMA4PeU7b2K/9FALXk2KF9J87txdHzXbUF9XRQRwSxcAs/fGaTnJeBFd7UoV22j3lzMLdM0Pw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/scheduler": {
@@ -19294,7 +19638,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -19305,7 +19649,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -19514,6 +19858,13 @@
       "optionalDependencies": {
         "bare-events": "^2.2.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -20020,7 +20371,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -20445,7 +20795,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21432,6 +21782,30 @@
         }
       }
     },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -21509,6 +21883,24 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.22",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.22.tgz",
+      "integrity": "sha512-+mJxdbmitioqqsql1Zro4dqT3t9HgmW4dxlPtkcsKFJhXSAMyk3lwawhQFxZjj2upJXzhrTUDsaDkZgJWnv3NA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jest": "29.7.0",
     "jest-environment-node": "^29.7.0",
     "mongodb-memory-server": "^10.1.3",
-    "nock": "13.5.6",
+    "nock": "^14.0.0-beta.19",
     "nodemailer": "^6.9.16",
     "nodemon": "^3.1.9",
     "nx": "20.3.1",

--- a/plugin/src/lib/api/translations.ts
+++ b/plugin/src/lib/api/translations.ts
@@ -9,8 +9,10 @@ import deepEqual from "deep-equal";
 import type {
   BlocksField as BlockField,
   CollectionConfig,
+  CollectionSlug,
   Field,
   GlobalConfig,
+  GlobalSlug,
   PayloadRequest,
   RichTextField,
 } from "payload";
@@ -124,13 +126,13 @@ export class payloadCrowdinSyncTranslationsApi {
     let doc;
     if (global) {
       doc = await this.payload.findGlobal({
-        slug: collection as keyof Config["globals"],
+        slug: collection as GlobalSlug,
         locale: this.sourceLocale,
         req: this.req,
       });
     } else {
       doc = await this.payload.findByID({
-        collection: collection as keyof Config["collections"],
+        collection: collection as CollectionSlug,
         id: documentId,
         locale: this.sourceLocale,
         req: this.req,


### PR DESCRIPTION
Includes an upgrade to `nock@beta`. Our `translations` class uses `fetch`. Since the upgrade to the node version, a nock upgrade is needed to allow calls using fetch to be intercepted in tests.

https://github.com/nock/nock

![Screenshot 2025-01-13 at 16 57 08](https://github.com/user-attachments/assets/23284ece-0ecd-438e-b829-686a300ff7a9)
