### PR TITLE
fix(package.json): add lexical as peerDependency

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -24,7 +24,8 @@
     "@payloadcms/richtext-lexical": "^3",
     "@payloadcms/richtext-slate": "^3",
     "@payloadcms/ui": "^3",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "lexical": "0.x"
   },
   "type": "module"
 }


### PR DESCRIPTION
Getting an error when testing in production (my main host installation for this plugin) after upgrading dependencies:

```
 Test suite failed to run

    Mismatching "lexical" dependency versions found: lexical@0.20.0 (Please change this to 0.21.0). All "lexical" packages must have the same version. This is an error with your set-up, not a bug in Payload. Please go to your package.json and ensure all "lexical" packages have the same version.

      at checkDependencies (node_modules/payload/src/utilities/dependencies/dependencyChecker.ts:63:17)
```

Attempt to resolve by adding `lexical` as a peer dependency.