### PR TITLE
feat(utilities): support deep nested localized fields

### DIFF
--- a/dev/src/tests/globals/home.test.ts
+++ b/dev/src/tests/globals/home.test.ts
@@ -120,6 +120,16 @@ describe('global: Home', () => {
         {
           "parentGroup": {
             "preTitle": "Parent group preTitle",
+            "subGroupOne": {
+              "ctaText": "SubGroupOne ctaText",
+              "text": "SubGroupOne text",
+              "title": "SubGroupOne title",
+            },
+            "subGroupTwo": {
+              "ctaText": "SubGroupTwo ctaText",
+              "text": "SubGroupTwo text",
+              "title": "SubGroupTwo title",
+            },
             "title": "Parent group title",
           },
         }

--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -115,12 +115,11 @@ export const getLocalizedFields = ({
     // exclude group, array and block fields with no localized fields
     // TODO: find a better way to do this - block, array and group logic is duplicated, and this filter needs to be compatible with field extraction logic later in this function
     .filter((field) => {
-      const localizedParent = hasLocalizedProp(field);
       if (field.type === "group" || field.type === "array") {
         return containsLocalizedFields({
           fields: field.fields,
           type,
-          localizedParent,
+          localizedParent: localizedParent || hasLocalizedProp(field),
           isLocalized,
         });
       }
@@ -129,7 +128,7 @@ export const getLocalizedFields = ({
           containsLocalizedFields({
             fields: block.fields,
             type,
-            localizedParent,
+            localizedParent: localizedParent || hasLocalizedProp(field),
             isLocalized,
           })
         );
@@ -138,14 +137,13 @@ export const getLocalizedFields = ({
     })
     // recursion for group, array and blocks field
     .map((field) => {
-      const localizedParent = hasLocalizedProp(field);
       if (field.type === "group" || field.type === "array") {
         return {
           ...field,
           fields: getLocalizedFields({
             fields: field.fields,
             type,
-            localizedParent,
+            localizedParent: localizedParent || hasLocalizedProp(field),
             isLocalized,
           }),
         };
@@ -157,7 +155,7 @@ export const getLocalizedFields = ({
               containsLocalizedFields({
                 fields: block.fields,
                 type,
-                localizedParent,
+                localizedParent: localizedParent || hasLocalizedProp(field),
                 isLocalized,
               })
             ) {
@@ -166,7 +164,7 @@ export const getLocalizedFields = ({
                 fields: getLocalizedFields({
                   fields: block.fields,
                   type,
-                  localizedParent,
+                  localizedParent: localizedParent || hasLocalizedProp(field),
                   isLocalized,
                 }),
               };


### PR DESCRIPTION
Localize fields deep nested within localized fields.

## Rationale

https://github.com/thompsonsj/payload-crowdin-sync/pull/255 documents the situation before this change and identifies the issue.

The design of this plugin to date has only localized direct child fields inside a localized field. In some cases on production, the localized prop was used on fields nested deeply within another localized field in order to activate localization.

It is clear following https://github.com/payloadcms/payload/pull/7933 that this is not the right approach. Localized fields within localized fields are redundant. This makes sense conceptually. Furthermore, removing nested localized fields is now default behaviour in Payload CMS: https://github.com/payloadcms/payload/pull/7933.

As a result, this plugin should ensure that all appropriate fields within a localized field, no matter how deeply nested, are identified for localization.

## Plugin caveat

Note one important caveat of using this plugin to localize content. It may be the case that a field that contains many fields is localized because the desired effect is that each locale may have a completely different structure.

A simple example of an array field. If localized at the array level, in Payload CMS each locale can have a different number of array items.

```
{
  type: "array",
  localized: true,
  fields: [
      {
        name: "title",
        type: "text",
      },
    ]
}
```

If the `title` field is localized, then in Payload CMS, every array item will be included in each locale and localization takes place on each array item's title field.

```
{
  type: "array",
  fields: [
      {
        name: "title",
        type: "text",
        localized: true,
      },
    ]
}
```

When using this plugin, the number of array items will be the same regardless of which localization strategy is used. This is because the source translation defines the number of array items. In these cases, if the additional flexibility is desired, it may be necessary to disable Crowdin translation for a given field and localize directly in the CMS.