### PR TITLE
feat(getlocalizedfields): exclude based on custom prop

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -286,6 +286,32 @@ On save draft or publish, content from [localized fields](https://payloadcms.com
 
 <img width="1000" alt="Screenshot 2024-02-06 at 22 02 38" src="https://github.com/thompsonsj/payload-crowdin-sync/assets/44806974/2c31050d-fee4-4275-bca2-7e4b48743999">
 
+#### Exclude fields
+
+In some cases, you may wish to localize fields but prevent them being synced to Crowdin. e.g. a slug field that autogenerates based on title.
+
+There are two ways to indicate to the plugin that a field should be ignored. In your field config:
+
+- add `{ custom: { crowdinSync: { disable: true } }}` (preferred); or
+- include the string `Not sent to Crowdin. Localize in the CMS.` in `admin.description` (may be removed in a future version).
+
+Example:
+
+```ts
+import type { Field } from 'payload';
+
+const field: Field = {
+  name: 'textLocalizedField',
+  type: 'text',
+  localized: true,
+  custom: {
+    crowdinSync: {
+      disable: true,
+    }
+  }
+}
+```
+
 ### Download translations
 
 To load translations into Payload CMS, use either: 

--- a/plugin/src/lib/utilities/getLocalizedFields.spec.ts
+++ b/plugin/src/lib/utilities/getLocalizedFields.spec.ts
@@ -40,6 +40,33 @@ describe('fn: getLocalizedFields', () => {
       ]);
     });
 
+    it('excludes a localized text field based on the custom field property', () => {
+      const fields: Field[] = [
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'textLocalizedFieldWithExcludeCustomProperty',
+          type: 'text',
+          localized: true,
+          custom: {
+            crowdinSync: {
+              disable: true,
+            }
+          }
+        },
+      ];
+      expect(getLocalizedFields({ fields })).toEqual([
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+      ]);
+    });
+
     it('includes a richText field', () => {
       const fields: Field[] = [
         {

--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -279,7 +279,7 @@ export const isLocalizedField = (
 ) =>
   (hasLocalizedProp(field) || addLocalizedProp) &&
   localizedFieldTypes.includes(field.type) &&
-  !excludeBasedOnDescription(field) &&
+  !excludeBasedOnConfig(field) &&
   (field as FieldWithName).name !== "id";
 
 /**
@@ -291,12 +291,16 @@ export const isLocalizedField = (
 export const reLocalizeField = (
   field: Field,
 ) => localizedFieldTypes.includes(field.type) &&
-  !excludeBasedOnDescription(field) &&
+  !excludeBasedOnConfig(field) &&
   (field as FieldWithName).name !== "id";
 
-const excludeBasedOnDescription = (field: Field) => {
+const excludeBasedOnConfig = (field: Field) => {
   const description = `${get(field, "admin.description", "")}`;
   if (description.includes("Not sent to Crowdin. Localize in the CMS.")) {
+    return true;
+  }
+  const custom = get(field, "custom.crowdinSync.disable", false);
+  if (custom) {
     return true;
   }
   return false;


### PR DESCRIPTION
Back in Apr 2023, support for a `custom` property was added to field configs in Payload CMS. See https://github.com/payloadcms/payload/pull/2436.

Before this property existed, we were using a workaround to indicate in field config that fields should be excluded from localization via Crowdin. This was added in https://github.com/thompsonsj/payload-crowdin-sync/pull/35.

The downsides of the workaround:

- brittle - relies on a very specific (and fairly long) string to be present in `admin.description`; and
- affects the frontend - `admin.description` is displayed alongside a field.

Using the `custom` property avoids these downsides (although being able to see visibly that a field is not sent to Crowdin may be considered a positive?).