### PR TITLE
Bugfix/missing organizaion parameter credentials

### DIFF
--- a/plugin/src/lib/api/files/index.ts
+++ b/plugin/src/lib/api/files/index.ts
@@ -34,7 +34,7 @@ interface IupdateCrowdinFile extends IcreateOrUpdateFile {
 }
 
 export class payloadCrowdinSyncFilesApi {
-  sourceFilesApi: SourceFiles; 
+  sourceFilesApi: SourceFiles;
   uploadStorageApi: UploadStorage;
   projectId: number;
   directoryId?: number;
@@ -46,6 +46,9 @@ export class payloadCrowdinSyncFilesApi {
     const credentials: Credentials = {
       token: pluginOptions.token,
     };
+    if (pluginOptions.organization) {
+      credentials.organization = pluginOptions.organization;
+    }
     const { sourceFilesApi, uploadStorageApi } = new crowdin.default(credentials);
     this.projectId = pluginOptions.projectId;
     this.directoryId = pluginOptions.directoryId;

--- a/plugin/src/lib/api/translations.ts
+++ b/plugin/src/lib/api/translations.ts
@@ -202,6 +202,7 @@ export class payloadCrowdinSyncTranslationsApi {
               draft,
               data: report[locale].latestTranslations,
               req: this.req,
+              overrideLock: true,
             });
           } catch (error) {
             console.log(
@@ -231,7 +232,7 @@ export class payloadCrowdinSyncTranslationsApi {
     collection: string,
     global: boolean
   ): CollectionConfig | GlobalConfig {
-    
+
     return getCollectionConfig(
       collection,
       global,

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext", // oder "ES2022", "ES2021", "ES2020"
+    "target": "ESNext",
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ESNext", // oder "ES2022", "ES2021", "ES2020"
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
We had again issues with org so i found we missing the organisation in the credentials.

also we had issues with document locking so we could just overwrite lock

Also while debugging the issue i saw that the code is build for es5 support and uses code without async/await. I think there is no reason to use esnext as payload is also using it