### PR TITLE
fix(pluginfields): sync all translations infinite loop

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
+  "main": "./src/index.ts", 
   "peerDependencies": {
     "payload": "^3",
     "@payloadcms/db-mongodb": "^3",
@@ -27,5 +28,11 @@
     "react": "^19.0.0",
     "lexical": "0.x"
   },
-  "type": "module"
+  "type": "module",
+  "engines": {
+    "node": "^18.20.2 || >=20.9.0"
+  },
+  "volta": {
+    "node": "23.5.0"
+  }
 }

--- a/plugin/src/lib/api/translations.ts
+++ b/plugin/src/lib/api/translations.ts
@@ -178,6 +178,10 @@ export class payloadCrowdinSyncTranslationsApi {
                 crowdinArticleDirectory: ((doc as any)["crowdinArticleDirectory"]).id,
               },
               req: this.req,
+              context: {
+                // set a flag to prevent from running again
+                triggerAfterChange: false,
+              },
             });
           } catch (error) {
             console.log(
@@ -204,6 +208,10 @@ export class payloadCrowdinSyncTranslationsApi {
               data: report[locale].latestTranslations,
               req: this.req,
               overrideLock: true,
+              context: {
+                // set a flag to prevent from running again
+                triggerAfterChange: false,
+              },
             });
           } catch (error) {
             console.log(

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -151,14 +151,6 @@ export const pluginCollectionOrGlobalFields = ({
                 })
               }
             } else {
-              if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
-                console.log('updatePayloadTranslation', {
-                  updated: 'yes',
-                  articleDirectoryId: context['articleDirectoryId'],
-                  draft: context['draft'],
-                  dryRun: false,
-                })
-              }
               await updatePayloadTranslation({
                 articleDirectoryId: context['articleDirectoryId'],
                 pluginOptions,

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -110,6 +110,10 @@ export const pluginCollectionOrGlobalFields = ({
       },
       hooks: {
         beforeChange: [async ({ context, siblingData }) => {
+          // return if flag was previously set
+          if (context.triggerAfterChange === false) {
+            return
+          }
           if (siblingData["syncAllTranslations"] && siblingData["crowdinArticleDirectory"]) {
             // is this a draft?
             const draft = Boolean(siblingData["_status"] && siblingData["_status"] !== 'published')
@@ -123,6 +127,10 @@ export const pluginCollectionOrGlobalFields = ({
           siblingData["syncAllTranslations"] = undefined;
         }],
         afterChange: [async ({ context, req }) => {
+          // return if flag was previously set
+          if (context.triggerAfterChange === false) {
+            return
+          }
           // type check context, if valid we can safely assume translation updates are desired
           if (typeof context['articleDirectoryId'] === 'string' && typeof context['draft'] === 'boolean' && typeof context["syncAllTranslations"] === 'boolean') {
             if (process.env.PAYLOAD_CROWDIN_SYNC_USE_JOBS) {
@@ -143,6 +151,14 @@ export const pluginCollectionOrGlobalFields = ({
                 })
               }
             } else {
+              if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
+                console.log('updatePayloadTranslation', {
+                  updated: 'yes',
+                  articleDirectoryId: context['articleDirectoryId'],
+                  draft: context['draft'],
+                  dryRun: false,
+                })
+              }
               await updatePayloadTranslation({
                 articleDirectoryId: context['articleDirectoryId'],
                 pluginOptions,


### PR DESCRIPTION
https://github.com/thompsonsj/payload-crowdin-sync/pull/263 did not fix the infinite loop issue.

It is caused by https://payloadcms.com/docs/hooks/context#preventing-infinite-loops. This changes fixes the issue using the method described in the docs.

Despite being a virtual field, the `afterChange` hook in `syncAllTranslations` is being triggered multiple times. This must be something to do with race conditions/multiple calls running around the same time. Regardless, logic is added to prevent the `afterChange` hook being re-triggered by a local API update operation.

Note: check the build after this is released. An entrypoint is added so that `npm link` works locally, but I am concerned this break the distribution somehow.