### PR TITLE
fix(packagejson): remove main entry

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "main": "./src/index.ts",
   "peerDependencies": {
     "payload": "^3",
     "@payloadcms/db-mongodb": "^3",


### PR DESCRIPTION
As predicted in https://github.com/thompsonsj/payload-crowdin-sync/pull/271, the `main` entry breaks the distribution. Remove.