### PR TITLE
fix(bydocument): check lexical blocks article directory exists

### DIFF
--- a/dev/src/tests/fields/lexical-editor-with-multiple-blocks.fixture.ts
+++ b/dev/src/tests/fields/lexical-editor-with-multiple-blocks.fixture.ts
@@ -208,3 +208,194 @@ export const fixture = {
       "direction": "ltr"
   }
 } as Policy['content']
+
+export const fixture2 = {
+    "root": {
+        "type": "root",
+        "format": "",
+        "indent": 0,
+        "version": 1,
+        "children": [
+            {
+                "format": "",
+                "type": "block",
+                "version": 2,
+                "fields": {
+                    "id": "65d67d2591c92e447e7472f7",
+                    "blockName": "",
+                    "blockType": "cta",
+                    "link": {
+                      "text": "Download payload-crowdin-sync on npm!",
+                      "href": "https://www.npmjs.com/package/payload-crowdin-sync",
+                      "type": "external",
+                    },
+                    "select": "primary"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "A bulleted list in-between some blocks consisting of:",
+                        "type": "text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1
+            },
+            {
+                "children": [
+                    {
+                        "children": [
+                            {
+                                "detail": 0,
+                                "format": 0,
+                                "mode": "normal",
+                                "style": "",
+                                "text": "one bullet list item; and",
+                                "type": "text",
+                                "version": 1
+                            }
+                        ],
+                        "direction": "ltr",
+                        "format": "",
+                        "indent": 0,
+                        "type": "listitem",
+                        "version": 1,
+                        "value": 1
+                    },
+                    {
+                        "children": [
+                            {
+                                "detail": 0,
+                                "format": 0,
+                                "mode": "normal",
+                                "style": "",
+                                "text": "another!",
+                                "type": "text",
+                                "version": 1
+                            }
+                        ],
+                        "direction": "ltr",
+                        "format": "",
+                        "indent": 0,
+                        "type": "listitem",
+                        "version": 1,
+                        "value": 2
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "list",
+                "version": 1,
+                "listType": "bullet",
+                "start": 1,
+                "tag": "ul"
+            },
+            {
+                "format": "",
+                "type": "block",
+                "version": 2,
+                "fields": {
+                    "id": "65d67d8191c92e447e7472f8",
+                    "blockName": "",
+                    "blockType": "highlight",
+                    "color": "green",
+                    "content": {
+                        "root": {
+                            "type": "root",
+                            "format": "",
+                            "indent": 0,
+                            "version": 1,
+                            "children": [
+                                {
+                                    "children": [
+                                        {
+                                            "detail": 0,
+                                            "format": 0,
+                                            "mode": "normal",
+                                            "style": "",
+                                            "text": "The plugin parses your block configuration for the Lexical rich text editor. It extracts all block values from the rich text field and then treats this config/data combination as a regular `blocks` field.",
+                                            "type": "text",
+                                            "version": 1
+                                        }
+                                    ],
+                                    "direction": "ltr",
+                                    "format": "",
+                                    "indent": 0,
+                                    "type": "paragraph",
+                                    "version": 1
+                                },
+                                {
+                                    "children": [
+                                        {
+                                            "detail": 0,
+                                            "format": 0,
+                                            "mode": "normal",
+                                            "style": "",
+                                            "text": "Markers are placed in the html and this content is restored into the correct place on translation.",
+                                            "type": "text",
+                                            "version": 1
+                                        }
+                                    ],
+                                    "direction": "ltr",
+                                    "format": "",
+                                    "indent": 0,
+                                    "type": "paragraph",
+                                    "version": 1
+                                }
+                            ],
+                            "direction": "ltr"
+                        }
+                    },
+                    "heading": {
+                        "title": "Blocks are extracted into their own fields",
+                        "preTitle": "How the plugin handles blocks in the Lexical editor"
+                    }
+                }
+            },
+            {
+                "format": "",
+                "type": "block",
+                "version": 2,
+                "fields": {
+                    "id": "65d67e2291c92e447e7472f9",
+                    "blockName": "",
+                    "blockType": "imageText",
+                    "title": "Testing a range of fields",
+                    "image": "65d67e6a7fb7e9426b3f9f5f",
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "direction": null,
+                        "format": "",
+                        "indent": 0,
+                        "type": "listitem",
+                        "version": 1,
+                        "value": 1
+                    }
+                ],
+                "direction": null,
+                "format": "",
+                "indent": 0,
+                "type": "list",
+                "version": 1,
+                "listType": "bullet",
+                "start": 1,
+                "tag": "ul"
+            }
+        ],
+        "direction": "ltr"
+    }
+  } as Policy['content']

--- a/dev/src/tests/fields/lexical-editor-with-multiple-blocks.test.ts
+++ b/dev/src/tests/fields/lexical-editor-with-multiple-blocks.test.ts
@@ -8,7 +8,7 @@ import {
   utilities,
 } from 'payload-crowdin-sync'
 import Policies from '../../collections/Policies'
-import { fixture } from './lexical-editor-with-multiple-blocks.fixture'
+import { fixture, fixture2 } from './lexical-editor-with-multiple-blocks.fixture'
 import nock from 'nock'
 import { pluginConfig } from '../helpers/plugin-config'
 import { CrowdinArticleDirectory, Policy } from '../../payload-types'
@@ -668,6 +668,7 @@ describe('Lexical editor with multiple blocks', () => {
       collection: 'policies',
       data: {
         title: 'Test policy',
+        content: fixture2,
       },
     })) as any
     const lexicalBlocksArticleDirectory: CrowdinArticleDirectory = (await getArticleDirectory({

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -15,6 +15,16 @@ Rationale:
 - Remove the need for richTextBlockFieldNameSeparator. the use of this led to field names that don't exist.
 - Logical - fields in blocks are easier to treat as a new 'document' rather than continuing to name them with increasing long field names to describe where they are nested.
 
+### Lexical blocks article directory
+
+Within an article directory (represented by a document in the `CrowdinArticleDirectories` collection), a folder is created for blocks within a Lexical field. This folder is named by combining the `lexicalBlockFolderPrefix` plugin option and the Lexical field name.
+
+e.g. `lex.content`.
+
+These block collections are treated as 'sub-articles', meaning that plugin logic is reused to parse Lexical field blocks as if they were top-level articles (documents in a Payload collection).
+
+Such folders on Crowdin are also referenced using documents in the `CrowdinArticleDirectories` collection. Lexical blocks article directories will have an id that corresponds to the Crowdin folder name (e.g. `lex.content`) and a parent relationship to another document in the `CrowdinArticleDirectories` collection.
+
 ### Source Lexical block content
 
 Lexical block content from the source locale (e.g. `en`) is merged back into Lexical block translations.

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -2,6 +2,7 @@
   "name": "payload-crowdin-sync",
   "version": "0.35.0",
   "description": "Automatically upload/sync localized fields from the default locale to Crowdin. Make these fields read-only in other locales and update them using Crowdin translations.",
+  "main": "./src/index.ts",
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/.bin/jest --forceExit --detectOpenHandles",
     "prettier": "npx prettier . --write"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -2,7 +2,6 @@
   "name": "payload-crowdin-sync",
   "version": "0.35.0",
   "description": "Automatically upload/sync localized fields from the default locale to Crowdin. Make these fields read-only in other locales and update them using Crowdin translations.",
-  "main": "./src/index.ts",
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/.bin/jest --forceExit --detectOpenHandles",
     "prettier": "npx prettier . --write"

--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -10,7 +10,7 @@ const require = createRequire(import.meta.url);
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const crowdin = require('@crowdin/crowdin-api-client');
-import { Credentials, SourceFiles } from "@crowdin/crowdin-api-client";
+import { Credentials, ResponseObject, SourceFiles, SourceFilesModel } from "@crowdin/crowdin-api-client";
 
 interface IfindOrCreateCollectionDirectory {
   collectionSlug: CollectionSlug | "globals";
@@ -117,11 +117,11 @@ export class filesApiByDocument {
           collectionSlug: this.global ? "globals" : this.collectionSlug,
         });
 
-      const parent: CrowdinArticleDirectory = isCrowdinArticleDirectory(this.parent) ? this.parent : this.parent && await this.req.payload.findByID({
+      const parent = isCrowdinArticleDirectory(this.parent) ? this.parent : this.parent && await this.req.payload.findByID({
           collection: "crowdin-article-directories",
           id: this.parent,
           req: this.req,
-        }) as any;
+        }) as CrowdinArticleDirectory;
 
       // Create article directory on Crowdin
       const name = this.global ? this.collectionSlug : this.document.id
@@ -131,8 +131,8 @@ export class filesApiByDocument {
         this.req.payload
       )
       const useAsTitle = (collectionConfig as CollectionConfig)?.admin?.useAsTitle
-      
-      const crowdinDirectory = await this.crowdinCreateDirectory({
+
+      crowdinPayloadArticleDirectory = await this.crowdinFindOrCreateDirectory({
         parent,
         crowdinPayloadCollectionDirectory,
         name,
@@ -140,27 +140,9 @@ export class filesApiByDocument {
       });
 
       // Store result in Payload CMS
-      const result = await this.req.payload.create({
-        collection: "crowdin-article-directories",
-        data: {
-          ...(crowdinPayloadCollectionDirectory?.['id'] && {
-            crowdinCollectionDirectory: `${crowdinPayloadCollectionDirectory?.['id']}`,
-          }),
-          originalId: crowdinDirectory.data.id,
-          directoryId: crowdinDirectory.data.directoryId,
-          name,
-          reference: {
-            createdAt: crowdinDirectory.data.createdAt,
-            updatedAt: crowdinDirectory.data.updatedAt,
-            projectId: this.projectId,
-          },
-          ...(parent && {
-            parent: parent.id,
-          })
-        },
-        req: this.req,
-      }) as unknown;
-      crowdinPayloadArticleDirectory = result as CrowdinArticleDirectory
+      if (!crowdinPayloadArticleDirectory) {
+        throw new Error("Crowdin article directory not found");
+      }
       const crowdinArticleDirectory = crowdinPayloadArticleDirectory.id
 
       // Associate result with document
@@ -211,6 +193,11 @@ export class filesApiByDocument {
 
     if (query.totalDocs === 0) {
       // Create collection directory on Crowdin
+      if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
+        console.log(
+          `Creating collection directory on Crowdin: ${collectionSlug}`
+        );
+      }
       const crowdinDirectory = await this.sourceFilesApi.createDirectory(
         this.projectId,
         {
@@ -245,7 +232,47 @@ export class filesApiByDocument {
     return crowdinPayloadCollectionDirectory;
   }
 
-  async crowdinCreateDirectory({
+  /**
+   * Check if a directory exists on Crowdin
+   * 
+   * Field directories are stored in article directories.
+   * 
+   * The existence check is done in Payload CMS - 
+   * check for a CrowdinArticleDirectory with the same name.
+   */
+  async crowdinFindFieldDirectory({
+    parent,
+    name,
+  }: {
+    parent: CrowdinArticleDirectory
+    name: string
+  }) {
+    try {
+      const result = await this.req.payload.find({
+        collection: "crowdin-article-directories",
+        where: {
+          name: {
+            equals: name,
+          },
+          parent: {
+            equals: parent.id,
+          }
+        }
+      })
+      if (result.totalDocs === 0) {
+        return undefined
+      }
+      return result.docs[0] as CrowdinArticleDirectory
+    }
+    catch (error) {
+      console.error(error);
+    }
+  }
+
+  /**
+   * Create a directory on Crowdin
+   */
+  async crowdinFindOrCreateDirectory({
     parent,
     crowdinPayloadCollectionDirectory,
     name,
@@ -257,6 +284,16 @@ export class filesApiByDocument {
     useAsTitle?: string
   }) {
     try {
+      // Check if directory already exists
+      const existingDirectory = parent && await this.crowdinFindFieldDirectory({
+        parent,
+        name,
+      });
+      if (existingDirectory) {
+        // Directory already exists
+        return existingDirectory
+      }
+
       const crowdinDirectory = await this.sourceFilesApi.createDirectory(
         this.projectId,
         {
@@ -267,9 +304,58 @@ export class filesApiByDocument {
             : useAsTitle && this.document[useAsTitle] || this.document.title || this.document.name, // no tests for this Crowdin metadata, but makes it easier for translators
         }
       );
-      return crowdinDirectory
+      const result = await this.payloadStoreCrowdinDirectory({
+        crowdinDirectory,
+        crowdinPayloadCollectionDirectory,
+        name,
+        parent,
+      });
+      return result as CrowdinArticleDirectory
     }
     catch (error) {
+      console.error(error);
+    }
+  }
+
+  /**
+   * Store a record of the Crowdin directory in Payload CMS
+   * 
+   * This is how we can find the directory on Crowdin later.
+   */
+  async payloadStoreCrowdinDirectory({
+    crowdinDirectory,
+    crowdinPayloadCollectionDirectory,
+    name,
+    parent,
+  }: {
+    crowdinDirectory: ResponseObject<SourceFilesModel.Directory>
+    crowdinPayloadCollectionDirectory?: CrowdinCollectionDirectory
+    name: string
+    parent?: CrowdinArticleDirectory
+  }) {
+    try {
+      const result = await this.req.payload.create({
+        collection: "crowdin-article-directories",
+        data: {
+          ...(crowdinPayloadCollectionDirectory?.['id'] && {
+            crowdinCollectionDirectory: `${crowdinPayloadCollectionDirectory?.['id']}`,
+          }),
+          originalId: crowdinDirectory.data.id,
+          directoryId: crowdinDirectory.data.directoryId,
+          name,
+          reference: {
+            createdAt: crowdinDirectory.data.createdAt,
+            updatedAt: crowdinDirectory.data.updatedAt,
+            projectId: this.projectId,
+          },
+          ...(parent && {
+            parent: parent.id,
+          })
+        },
+        req: this.req,
+      });
+      return result as CrowdinArticleDirectory
+    } catch (error) {
       console.error(error);
     }
   }

--- a/plugin/src/lib/api/files/document.ts
+++ b/plugin/src/lib/api/files/document.ts
@@ -289,6 +289,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
             sourceBlocks: blockContent
           }),
         });
+        
       } else {
         const html = "<span>lexical configuration not found</span>"
         await this.createOrUpdateFile({
@@ -319,7 +320,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
     blockConfig: BlockField
     name: string
     req: PayloadRequest
-  }) {    
+  }) {
     // directory name must be unique from file names - Crowdin API
     const folderName = `${this.pluginOptions.lexicalBlockFolderPrefix}${name}`
     /**


### PR DESCRIPTION
Our logic never checks whether a **Lexical blocks article directory** exists. The term Lexical blocks article directory is explained in docs added in this pull request.

This leads to an `Error: Invalid name given. Name must be unique` Crowdin API error when a localized document is updated - it tries to create the **Lexical blocks article directory** again.

This issue was time-consuming to debug because the Crowdin API call was failing silently - it seemed that the `await` call never resolved, stopping remaining code from executing. For this reason, this change includes a [refactor](#refactor).

Finally, we ensure this issue is covered in testing. See comment in code.

## Refactor

Wrap logic to create a directory on Crowdin in a try catch block. With this change, we can detect any issues with directory creation. Otherwise, in the case of an error, the operation fails silently - the `await` never resolves and subsequent logic is not executed - e.g. html file updates are not sent to Crowdin and the appropriate document in `CrowdinFiles` is not updated.

This highlight a more general issue - the refactor on this function was made difficult by the fact that there is too much logic in one function.

Additional logic has been wrapped into functions with try catch blocks. Having said that, more refactoring is recommended - try catch blocks need to be more prevalent when making Crowdin API calls in order to report on errors.

Example error post change:

```
Error: Invalid name given. Name must be unique
    at async filesApiByDocument.findOrCreateArticleDirectory (<project-dir>/plugin/src/lib/api/files/by-document.ts:144:31)
    at async filesApiByDocument.assertArticleDirectoryProvided (<project-dir>/plugin/src/lib/api/files/by-document.ts:97:30)
    at async filesApiByDocument.get (<project-dir>/plugin/src/lib/api/files/by-document.ts:86:4)
    at async payloadCrowdinSyncDocumentFilesApi.createLexicalBlocks (<project-dir>/plugin/src/lib/api/files/document.ts:348:21)
    at async payloadCrowdinSyncDocumentFilesApi.createOrUpdateHtmlFile (<project-dir>/plugin/src/lib/api/files/document.ts:276:10)
    at async eval (<project-dir>/plugin/src/lib/hooks/collections/afterChange.ts:222:6)
    at async createOrUpdateHtmlSource (<project-dir>/plugin/src/lib/hooks/collections/afterChange.ts:213:4)
    at async performAfterChange (<project-dir>/plugin/src/lib/hooks/collections/afterChange.ts:232:2)
  142 |       })
  143 |       try {
> 144 |       const crowdinDirectory = await this.sourceFilesApi.createDirectory(
      |                               ^
  145 |         this.projectId,
  146 |         {
  147 |           directoryId: (parent ? parent.originalId : crowdinPayloadCollectionDirectory?.['originalId']) as number, {
  code: 400,
  apiError: [Array],
  validationCodes: [Array]
}

```