### PR TITLE
fix(getlocalizedfields): respect exclude prop on group fields

### DIFF
--- a/plugin/src/lib/utilities/getLocalizedFields.spec.ts
+++ b/plugin/src/lib/utilities/getLocalizedFields.spec.ts
@@ -54,8 +54,8 @@ describe('fn: getLocalizedFields', () => {
           custom: {
             crowdinSync: {
               disable: true,
-            }
-          }
+            },
+          },
         },
       ];
       expect(getLocalizedFields({ fields })).toEqual([
@@ -304,6 +304,58 @@ describe('fn: getLocalizedFields', () => {
             },
           ],
         },
+      ];
+      expect(getLocalizedFields({ fields })).toEqual(expected);
+    });
+
+    it('excludes localized fields within a tab from an array with a localization setting on the array field and the "exclude" custom property', () => {
+      /**
+       * Note that the localized prop is added to fields in this case.
+       */
+      const fields: Field[] = [
+        ...mixedFieldCollection,
+        {
+          name: 'arrayField',
+          type: 'array',
+          localized: true,
+          custom: {
+            crowdinSync: {
+              disable: true,
+            },
+          },
+          fields: [
+            {
+              type: 'tabs',
+              tabs: [
+                {
+                  label: 'Text',
+                  fields: [
+                    {
+                      name: 'title',
+                      type: 'text',
+                    },
+                    {
+                      name: 'text',
+                      type: 'text',
+                    },
+                    {
+                      name: 'textarea',
+                      type: 'textarea',
+                    },
+                    {
+                      name: 'select',
+                      type: 'select',
+                      options: ['one', 'two'],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      const expected = [
+        ...localizedFieldCollection,
       ];
       expect(getLocalizedFields({ fields })).toEqual(expected);
     });

--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -122,7 +122,7 @@ export const getLocalizedFields = ({
         return containsLocalizedFields({
           fields: field.fields,
           type,
-          localizedParent: localizedParent || hasLocalizedProp(field),
+          localizedParent: localizedParent || isLocalized(field),
           isLocalized,
         });
       }
@@ -131,7 +131,7 @@ export const getLocalizedFields = ({
           containsLocalizedFields({
             fields: block.fields,
             type,
-            localizedParent: localizedParent || hasLocalizedProp(field),
+            localizedParent: localizedParent || isLocalized(field),
             isLocalized,
           }),
         );
@@ -146,7 +146,7 @@ export const getLocalizedFields = ({
           fields: getLocalizedFields({
             fields: field.fields,
             type,
-            localizedParent: localizedParent || hasLocalizedProp(field),
+            localizedParent: localizedParent || isLocalized(field),
             isLocalized,
           }),
         };
@@ -158,7 +158,7 @@ export const getLocalizedFields = ({
               containsLocalizedFields({
                 fields: block.fields,
                 type,
-                localizedParent: localizedParent || hasLocalizedProp(field),
+                localizedParent: localizedParent || isLocalized(field),
                 isLocalized,
               })
             ) {
@@ -167,7 +167,7 @@ export const getLocalizedFields = ({
                 fields: getLocalizedFields({
                   fields: block.fields,
                   type,
-                  localizedParent: localizedParent || hasLocalizedProp(field),
+                  localizedParent: localizedParent || isLocalized(field),
                   isLocalized,
                 }),
               };
@@ -296,7 +296,7 @@ const hasLocalizedProp = (field: Field) =>
  */
 export const isLocalizedField = (field: Field, addLocalizedProp = false) =>
   (hasLocalizedProp(field) || addLocalizedProp) &&
-  localizedFieldTypes.includes(field.type) &&
+  (localizedFieldTypes.includes(field.type) || containsNestedFields(field)) &&
   !excludeBasedOnConfig(field) &&
   (field as FieldWithName).name !== 'id';
 


### PR DESCRIPTION
In the following scenario, ensure no fields are returned (respecting the existence of the exclude property).

This type of scenario happens when group/array/blocks fields are localized within Payload CMS only, and the user wants to prevent the values being sent to Crowdin.

```ts
{
  name: 'arrayField',
  type: 'array',
  localized: true,
  custom: {
    crowdinSync: {
      disable: true,
    },
  },
  fields: [
    ...fields,
  ],
}
```