### PR TITLE
fix(pluginfields): unset crowdinArticleDirectory on duplicate

### DIFF
--- a/dev/src/tests/collections/localized-posts-with-condition.test.ts
+++ b/dev/src/tests/collections/localized-posts-with-condition.test.ts
@@ -196,16 +196,11 @@ describe("Collection: Localized Posts With Conditon", () => {
         .post(
           `/api/v2/storages`
         )
-        .twice()
         .reply(200, mockClient.addStorage())
         .post(
           `/api/v2/projects/${pluginOptions.projectId}/files`
         )
         .reply(200, mockClient.createFile({}))
-        .put(
-          `/api/v2/projects/${pluginOptions.projectId}/files/${fileId}`
-        )
-        .reply(200, mockClient.updateOrRestoreFile({ fileId }))
 
       const post = await payload.create({
         collection: "localized-posts-with-condition",
@@ -225,10 +220,13 @@ describe("Collection: Localized Posts With Conditon", () => {
       const duplicatedPost = await payload.duplicate({
         id: post.id,
         collection: "localized-posts-with-condition",
+        data: {
+          translateWithCrowdin: false,
+        },
         draft: true,
       });
 
-      expect((result.crowdinArticleDirectory as CrowdinArticleDirectory).id).not.toEqual((duplicatedPost.crowdinArticleDirectory as CrowdinArticleDirectory).id);
+      expect((result.crowdinArticleDirectory as CrowdinArticleDirectory)?.id).not.toEqual((duplicatedPost.crowdinArticleDirectory as CrowdinArticleDirectory)?.id);
     });
 
     it("creates an article directory if the conditon is met on an existing article", async () => {

--- a/dev/src/tests/collections/localized-posts-with-condition.test.ts
+++ b/dev/src/tests/collections/localized-posts-with-condition.test.ts
@@ -186,26 +186,28 @@ describe("Collection: Localized Posts With Conditon", () => {
       expect(Object.prototype.hasOwnProperty.call(result, 'crowdinArticleDirectory')).toBeTruthy();
     });
 
-    it("creates an article directory if the conditon is met and does not copy this article directory to a duplicated post", async () => {
-      const fileId = 1079
+    it("creates an article directory if the conditon is met for a new document and creates a new article directory when this document is duplicated (does not copy the same article directory)", async () => {
       nock('https://api.crowdin.com')
         .post(
           `/api/v2/projects/${pluginOptions.projectId}/directories`
         )
+        .twice()
         .reply(200, mockClient.createDirectory({}))
         .post(
           `/api/v2/storages`
         )
+        .twice()
         .reply(200, mockClient.addStorage())
         .post(
           `/api/v2/projects/${pluginOptions.projectId}/files`
         )
+        .twice()
         .reply(200, mockClient.createFile({}))
 
       const post = await payload.create({
         collection: "localized-posts-with-condition",
         data: {
-          title: "Test post",
+          title: "Test post to be/has been duplicated",
           translateWithCrowdin: true,
         },
         draft: true,
@@ -220,9 +222,6 @@ describe("Collection: Localized Posts With Conditon", () => {
       const duplicatedPost = await payload.duplicate({
         id: post.id,
         collection: "localized-posts-with-condition",
-        data: {
-          translateWithCrowdin: false,
-        },
         draft: true,
       });
 

--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -101,6 +101,7 @@ export class filesApiByDocument {
   /** this is where the problem lies? */
   async findOrCreateArticleDirectory(): Promise<CrowdinArticleDirectory> {
     let crowdinPayloadArticleDirectory;
+    // null check - currently there is no way to unset a
     if (this.document.crowdinArticleDirectory) {
       // Update not possible. Article name needs to be updated manually on Crowdin.
       // The name of the directory is Crowdin specific helper text to give

--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -101,7 +101,6 @@ export class filesApiByDocument {
   /** this is where the problem lies? */
   async findOrCreateArticleDirectory(): Promise<CrowdinArticleDirectory> {
     let crowdinPayloadArticleDirectory;
-    // null check - currently there is no way to unset a
     if (this.document.crowdinArticleDirectory) {
       // Update not possible. Article name needs to be updated manually on Crowdin.
       // The name of the directory is Crowdin specific helper text to give

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -17,7 +17,7 @@ const crowdinArticleDirectoryField: Field = {
   hooks: {
     // ensure crowdinArticleDirectory is not copied to a duplicated document
     beforeDuplicate: [
-      () => undefined,
+      () => '',
     ],
   },
   /*admin: {

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -14,6 +14,12 @@ const crowdinArticleDirectoryField: Field = {
   type: "relationship",
   relationTo: "crowdin-article-directories",
   hasMany: false,
+  hooks: {
+    // ensure crowdinArticleDirectory is not copied to a duplicated document
+    beforeDuplicate: [
+      () => undefined,
+    ],
+  },
   /*admin: {
     readOnly: true,
     disabled: true,

--- a/plugin/src/lib/fields/pluginFields.ts
+++ b/plugin/src/lib/fields/pluginFields.ts
@@ -17,7 +17,7 @@ const crowdinArticleDirectoryField: Field = {
   hooks: {
     // ensure crowdinArticleDirectory is not copied to a duplicated document
     beforeDuplicate: [
-      () => '',
+      () => null,
     ],
   },
   /*admin: {


### PR DESCRIPTION
When a document is duplicated, the `crowdinArticleDirectory` is also copied over.

This leads to confusion because more than one document share the same directory on Crowdin.

Reset the `crowdinArticleDirectory` on duplicate. It [does not seem possible to unset this property](https://github.com/payloadcms/payload/discussions/3102), so set the value of the relationship to `null`. 

Doing so results in the plugin logic creating a new Crowdin article directory for the duplicated document because it processes the `afterRead` hook which determines that there is no `crowdinArticleDirectory` and thus creates a new one.

## Notes

Other approaches were considered.

### `crowdinArticleDirectory` refactor would solve this issue

https://github.com/thompsonsj/payload-crowdin-sync/pull/270 would solve this issue as this change stores document ids directly on Crowdin article directories themselves. So there is no chance to have the same relationship - the duplicated document will have a different id.

However, this is a big change/refactor so it's preferable to implement a fix in the meantime.

### Disable Crowdin translation for the duplicated document

Another approach would be to disable Crowdin translation for the duplicated document.

However, this is too complicated for the plugin to address - it would be more appropriate to configure this in the host installation.

- Collections can be configured to always translate every document. In this case, disabling translation for duplicated documents is not appropriate.
- Collections may use [the `condition` option](https://github.com/thompsonsj/payload-crowdin-sync/blob/main/plugin/README.md#collections).

In the case of the `condition` option, if a document is duplicated where Crowdin translation is active, the duplicated document will also sent for translation. For example, a condition may be that a `translateWithCrowdin` checkbox field is set to `true`. The duplicated document will also have this field set to `true`, so will send source translations to Crowdin.

This behaviour can be modified in  the host Payload configuration. In the example of a `translateWithCrowdin` checkbox field, use the [`beforeDuplicate` field hook](https://payloadcms.com/docs/hooks/fields#beforeduplicate) to set this value to `false` in the duplicated document. This forces the user to actively mark duplicated documents for translation by setting it to `true` manually if desired.

```ts
import { type Field } from 'payload'

const conditionField: Field = {
  name: "translateWithCrowdin",
  type: "checkbox",
  hooks: {
     // ensure translation is not active for a duplicated document
     beforeDuplicate: [
       () => false,
    ],
  }
}
```