### PR TITLE
fix(bydocument): nested lexical fields source translation

### DIFF
--- a/dev/src/collections/NestedFieldCollection.ts
+++ b/dev/src/collections/NestedFieldCollection.ts
@@ -93,6 +93,7 @@ const NestedFieldCollection: CollectionConfig = {
         BasicBlockRichTextField,
         BasicBlockMixedFields,
         TestBlockArrayOfRichText,
+        BasicBlockLexical,
       ],
     },
     // blocks - top level localized
@@ -106,6 +107,7 @@ const NestedFieldCollection: CollectionConfig = {
         BasicBlockRichTextField,
         BasicBlockMixedFields,
         TestBlockArrayOfRichText,
+        BasicBlockLexical,
       ],
     },
     // collapsible

--- a/dev/src/collections/fields/lexicalEditorWithBlocks.ts
+++ b/dev/src/collections/fields/lexicalEditorWithBlocks.ts
@@ -52,6 +52,26 @@ export const lexicalEditorWithBlocks: RichTextField = {
                   features: () => [
                     BoldTextFeature(),
                     LinkFeature({}),
+                    BlocksFeature({
+                      blocks: [
+                        {
+                          slug: "featureList",
+                          imageAltText: "Feature List block",
+                          fields: [
+                            {
+                              name: "items",
+                              type: "array",
+                              fields: [
+                                {
+                                  name: "text",
+                                  type: "text"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    })
                   ]
                 }),
               },

--- a/dev/src/payload-types.ts
+++ b/dev/src/payload-types.ts
@@ -526,6 +526,26 @@ export interface NestedFieldCollection {
             blockName?: string | null;
             blockType: 'testBlockArrayOfRichText';
           }
+        | {
+            content?: {
+              root: {
+                type: string;
+                children: {
+                  type: string;
+                  version: number;
+                  [k: string]: unknown;
+                }[];
+                direction: ('ltr' | 'rtl') | null;
+                format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+                indent: number;
+                version: number;
+              };
+              [k: string]: unknown;
+            } | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'basicBlockLexical';
+          }
       )[]
     | null;
   layoutTwo?:
@@ -592,6 +612,26 @@ export interface NestedFieldCollection {
             id?: string | null;
             blockName?: string | null;
             blockType: 'testBlockArrayOfRichText';
+          }
+        | {
+            content?: {
+              root: {
+                type: string;
+                children: {
+                  type: string;
+                  version: number;
+                  [k: string]: unknown;
+                }[];
+                direction: ('ltr' | 'rtl') | null;
+                format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+                indent: number;
+                version: number;
+              };
+              [k: string]: unknown;
+            } | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'basicBlockLexical';
           }
       )[]
     | null;
@@ -1131,6 +1171,13 @@ export interface NestedFieldCollectionSelect<T extends boolean = true> {
               id?: T;
               blockName?: T;
             };
+        basicBlockLexical?:
+          | T
+          | {
+              content?: T;
+              id?: T;
+              blockName?: T;
+            };
       };
   layoutTwo?:
     | T
@@ -1180,6 +1227,13 @@ export interface NestedFieldCollectionSelect<T extends boolean = true> {
                     message?: T;
                     id?: T;
                   };
+              id?: T;
+              blockName?: T;
+            };
+        basicBlockLexical?:
+          | T
+          | {
+              content?: T;
               id?: T;
               blockName?: T;
             };

--- a/dev/src/tests/translations/send/__fixtures__/block-richtext-block-nesting.fixture.ts
+++ b/dev/src/tests/translations/send/__fixtures__/block-richtext-block-nesting.fixture.ts
@@ -1,0 +1,154 @@
+import { NestedFieldCollection } from "@/payload-types";
+
+export const fixture = [
+{
+    "blockType": "basicBlockLexical",
+    "content": {
+    "root": {
+        "children": [
+        {
+            "children": [
+            {
+                "detail": 0,
+                "format": 0,
+                "mode": "normal",
+                "style": "",
+                "text": "Text in a Lexical field inside a block in the ",
+                "type": "text",
+                "version": 1
+            },
+            {
+                "children": [
+                {
+                    "detail": 0,
+                    "format": 0,
+                    "mode": "normal",
+                    "style": "",
+                    "text": "blocks field",
+                    "type": "text",
+                    "version": 1
+                }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "link",
+                "version": 3,
+                "fields": {
+                "linkType": "custom",
+                "newTab": false,
+                "url": "https://payloadcms.com/docs/fields/blocks"
+                },
+                "id": "688dd6e6a950db7862106961"
+            },
+            {
+                "detail": 0,
+                "format": 0,
+                "mode": "normal",
+                "style": "",
+                "text": ".",
+                "type": "text",
+                "version": 1
+            }
+            ],
+            "direction": "ltr",
+            "format": "",
+            "indent": 0,
+            "type": "paragraph",
+            "version": 1,
+            "textFormat": 0,
+            "textStyle": ""
+        },
+        {
+            "type": "block",
+            "version": 2,
+            "format": "",
+            "fields": {
+            "id": "688dd6eca950db7862106962",
+            "content": {
+                "root": {
+                "children": [
+                    {
+                    "children": [
+                        {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Text in a Lexical field in the 'Highlight' block. This block is embedded in a parent Lexical field within the 'Basic Block Lexical' block.",
+                        "type": "text",
+                        "version": 1
+                        }
+                    ],
+                    "direction": "ltr",
+                    "format": "",
+                    "indent": 0,
+                    "type": "paragraph",
+                    "version": 1,
+                    "textFormat": 0,
+                    "textStyle": ""
+                    },
+                    {
+                    "type": "block",
+                    "version": 2,
+                    "format": "",
+                    "fields": {
+                        "id": "688dd71aa950db7862106963",
+                        "blockName": "",
+                        "items": [
+                        {
+                            "id": "688dd71d258ffa0224ea6dac",
+                            "text": "Text in an array field in the 'Feature List' block. This block is embedded in a parent Lexical field within the 'Highlight' block."
+                        },
+                        {
+                            "id": "688dd71f258ffa0224ea6dae",
+                            "text": "The Payload Crowdin Sync plugin can parse complex field structures including blocks nested in Lexical fields nested in blocks nested in ...etc."
+                        }
+                        ],
+                        "blockType": "featureList"
+                    }
+                    },
+                    {
+                    "children": [],
+                    "direction": null,
+                    "format": "",
+                    "indent": 0,
+                    "type": "paragraph",
+                    "version": 1,
+                    "textFormat": 0,
+                    "textStyle": ""
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "root",
+                "version": 1
+                }
+            },
+            "blockName": "",
+            "blockType": "highlight",
+            "heading": {}
+            }
+        },
+        {
+            "children": [],
+            "direction": null,
+            "format": "",
+            "indent": 0,
+            "type": "paragraph",
+            "version": 1,
+            "textFormat": 0,
+            "textStyle": ""
+        }
+        ],
+        "direction": "ltr",
+        "format": "",
+        "indent": 0,
+        "type": "root",
+        "version": 1
+    }
+    },
+    "id": "688dd685258ffa0224ea6daa"
+  }
+] as NestedFieldCollection['layout']

--- a/dev/src/tests/translations/send/__snapshots__/blocks-richtext-block-nesting.test.ts.snap
+++ b/dev/src/tests/translations/send/__snapshots__/blocks-richtext-block-nesting.test.ts.snap
@@ -1,9 +1,20 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Translations fn: updateTranslation - custom serializer updates a Payload article with a \`richText\` field translation retrieved from Crowdin restoring table structure 1`] = `
-"<p>Text in a Lexical field inside a block in the <a href="https://payloadcms.com/docs/fields/blocks">
-        blocks field
-      </a>.</p><span data-block-id=688dd6eca950db7862106962 data-block-type=highlight></span><p><br /></p>"
+{
+  "blocks": {
+    "688dd71aa950db7862106963": {
+      "featureList": {
+        "items": {
+          "688dd71d258ffa0224ea6dac": {
+            "text": "Text in an array field in the 'Feature List' block. This block is embedded in a parent Lexical field within the 'Highlight' block.",
+          },
+          "688dd71f258ffa0224ea6dae": {
+            "text": "The Payload Crowdin Sync plugin can parse complex field structures including blocks nested in Lexical fields nested in blocks nested in ...etc.",
+          },
+        },
+      },
+    },
+  },
+}
 `;
-
-exports[`Translations fn: updateTranslation - custom serializer updates a Payload article with a \`richText\` field translation retrieved from Crowdin restoring table structure 2`] = `"[{"id":"688dd6eca950db7862106962","content":{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Text in a Lexical field in the 'Highlight' block. This block is embedded in a parent Lexical field within the 'Basic Block Lexical' block.","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1,"textFormat":0,"textStyle":""},{"type":"block","version":2,"format":"","fields":{"id":"688dd71aa950db7862106963","blockName":"","items":[{"id":"688dd71d258ffa0224ea6dac","text":"Text in an array field in the 'Feature List' block. This block is embedded in a parent Lexical field within the 'Highlight' block."},{"id":"688dd71f258ffa0224ea6dae","text":"The Payload Crowdin Sync plugin can parse complex field structures including blocks nested in Lexical fields nested in blocks nested in ...etc."}],"blockType":"featureList"}},{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1,"textFormat":0,"textStyle":""}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}},"blockName":"","blockType":"highlight","heading":{}}]"`;

--- a/dev/src/tests/translations/send/__snapshots__/blocks-richtext-block-nesting.test.ts.snap
+++ b/dev/src/tests/translations/send/__snapshots__/blocks-richtext-block-nesting.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Translations fn: updateTranslation - custom serializer updates a Payload article with a \`richText\` field translation retrieved from Crowdin restoring table structure 1`] = `
+"<p>Text in a Lexical field inside a block in the <a href="https://payloadcms.com/docs/fields/blocks">
+        blocks field
+      </a>.</p><span data-block-id=688dd6eca950db7862106962 data-block-type=highlight></span><p><br /></p>"
+`;
+
+exports[`Translations fn: updateTranslation - custom serializer updates a Payload article with a \`richText\` field translation retrieved from Crowdin restoring table structure 2`] = `"[{"id":"688dd6eca950db7862106962","content":{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Text in a Lexical field in the 'Highlight' block. This block is embedded in a parent Lexical field within the 'Basic Block Lexical' block.","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1,"textFormat":0,"textStyle":""},{"type":"block","version":2,"format":"","fields":{"id":"688dd71aa950db7862106963","blockName":"","items":[{"id":"688dd71d258ffa0224ea6dac","text":"Text in an array field in the 'Feature List' block. This block is embedded in a parent Lexical field within the 'Highlight' block."},{"id":"688dd71f258ffa0224ea6dae","text":"The Payload Crowdin Sync plugin can parse complex field structures including blocks nested in Lexical fields nested in blocks nested in ...etc."}],"blockType":"featureList"}},{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1,"textFormat":0,"textStyle":""}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}},"blockName":"","blockType":"highlight","heading":{}}]"`;

--- a/dev/src/tests/translations/send/blocks-richtext-block-nesting.test.ts
+++ b/dev/src/tests/translations/send/blocks-richtext-block-nesting.test.ts
@@ -1,0 +1,148 @@
+import { getFiles, getLexicalFieldArticleDirectories } from "payload-crowdin-sync";
+import nock from "nock";
+import { mockCrowdinClient } from "payload-crowdin-sync";
+import { pluginConfig } from "../../helpers/plugin-config"
+
+import { fixture } from "./__fixtures__/block-richtext-block-nesting.fixture";
+
+import { initPayloadInt } from '../../helpers/initPayloadInt'
+import type { Payload } from 'payload'
+import { CrowdinArticleDirectory } from "@/payload-types";
+
+let payload: Payload
+
+// const fixtureHtmlFr = '<div class="rich-text"><p>Text in a Lexical field inside a block in the <strong>block</strong> of a <em>Lexical field</em> of a <strong>Lexical field</strong> of a <strong>Lexical field</strong>.</p></div>'
+
+/**
+ * Test translations
+ *
+ * Ensure translations are retrieved, compared, and
+ * stored as expected.
+ */
+
+const pluginOptions = pluginConfig()
+const mockClient = mockCrowdinClient(pluginOptions)
+
+/**
+ * payload.config.custom-serializers.ts required for htmlToSlate.
+ * 
+ * Plugin options passed directly to payloadCrowdinSyncTranslationsApi - this API is initialized through `server.ts` at the moment. Can change this in the future to use internal functions.
+ */
+describe("Translations", () => {
+  beforeAll(async () => {
+    const initialized = await initPayloadInt()
+        ;({ payload } = initialized as {
+          payload: Payload
+        })
+  });
+
+  afterEach((done) => {
+    if (!nock.isDone()) {
+      throw new Error(
+        `Not all nock interceptors were used: ${JSON.stringify(
+          nock.pendingMocks()
+        )}`
+      );
+    }
+    nock.cleanAll()
+    done()
+  })
+
+  afterAll(async () => {
+    if (typeof payload.db.destroy === 'function') {
+      await payload.db.destroy()
+    }
+  });
+
+  describe("fn: updateTranslation - custom serializer", () => {
+    it("updates a Payload article with a `richText` field translation retrieved from Crowdin restoring table structure", async () => {
+      const fileId = 4674
+
+      nock("https://api.crowdin.com")
+        .post(
+          `/api/v2/projects/${pluginOptions.projectId}/directories`
+        )
+        .times(3)
+        .reply(200, mockClient.createDirectory({}))
+        .post(
+          `/api/v2/storages`
+        )
+        .reply(200, mockClient.addStorage())
+        .post(
+          `/api/v2/projects/${pluginOptions.projectId}/files`
+        )
+        .reply(200, mockClient.createFile({
+          fileId,
+        }))
+        /* .post(
+          `/api/v2/projects/${pluginOptions.projectId}/translations/builds/files/${fileId}`,
+          {
+            targetLanguageId: 'fr',
+          }
+        )
+        .reply(200, mockClient.buildProjectFileTranslation({
+          url: `https://api.crowdin.com/api/v2/projects/${pluginOptions.projectId}/translations/builds/${fileId}/download?targetLanguageId=fr`
+        }))
+        .get(
+          `/api/v2/projects/${pluginOptions.projectId}/translations/builds/${fileId}/download`
+        )
+        .query({
+          targetLanguageId: 'fr',
+        })
+        .reply(200, fixtureHtmlFr,
+        ) */;
+      const create = await payload.create({
+        collection: "nested-field-collection",
+        data: {
+          title: "Non-localized title",
+          layout: fixture,
+        },
+      });
+      // Crowdin file
+      const post = await payload.findByID({
+        collection: "nested-field-collection",
+        id: create.id,
+      })
+      const files = await getFiles( (post.crowdinArticleDirectory as CrowdinArticleDirectory)?.id, payload)
+      expect(files.length).toBe(1);
+      const file = files[0];
+      expect(file.fileData?.html).toMatchSnapshot();
+      expect(file.fileData?.sourceBlocks).toMatchSnapshot();
+      const childDirectories = await getLexicalFieldArticleDirectories({
+        payload,
+        parent: post.crowdinArticleDirectory,
+      })
+      expect(childDirectories.length).toBe(1);
+      const childDirectory = childDirectories[0]
+      const childDirectoryFiles = await getFiles(childDirectory.id, payload);
+      // here's the issue - Crowdin files are not created for the child directory. Is this a simple localization fix?
+      expect(childDirectoryFiles.length).toBeGreaterThan(0)
+      /* const regexp = /\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/g;
+      regexp.lastIndex = 1;
+      const str = file.docs[0].fileData?.html || ``;
+      const uuids = Array.from(str.matchAll(regexp), (m) => m[0]);
+      let fixtureHtmlWithUuids = fixtureHtml
+      uuids.forEach((uuid, index) => {
+        fixtureHtmlWithUuids = fixtureHtmlWithUuids.replace(`<uuid[${index}]>`, uuid)
+      })
+      expect(file.docs[0].fileData?.html).toEqual(fixtureHtmlWithUuids);
+      const translationsApi = new payloadCrowdinSyncTranslationsApi(
+        pluginOptions,
+        payload,
+      );
+      await translationsApi.updateTranslation({
+        documentId: `${post.id}`,
+        collection: "policies",
+        dryRun: false,
+      });
+      // retrieve translated post from Payload
+      const frResult = await payload.findByID({
+        collection: "policies",
+        id: post.id,
+        locale: "fr_FR",
+      });
+      
+      expect(frResult["content"]).toEqual(fixtureFr); */
+    });
+  });
+});

--- a/dev/src/tests/translations/send/blocks-richtext-block-nesting.test.ts
+++ b/dev/src/tests/translations/send/blocks-richtext-block-nesting.test.ts
@@ -113,7 +113,9 @@ describe("Translations", () => {
         parent: post.crowdinArticleDirectory,
       })
       expect(childDirectories.length).toBe(1);
+      console.log(childDirectories)
       const childDirectory = childDirectories[0]
+      expect(childDirectory.name).toEqual(`lex.layout.688dd685258ffa0224ea6daa.basicBlockLexical.content`)
       const childDirectoryFiles = await getFiles(childDirectory.id, payload);
       // here's the issue - Crowdin files are not created for the child directory. Is this a simple localization fix?
       expect(childDirectoryFiles.length).toBeGreaterThan(0)

--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -1,6 +1,6 @@
 import { CrowdinArticleDirectory, CrowdinCollectionDirectory } from "../../payload-types";
 import { isCrowdinArticleDirectory, PluginOptions } from "../../types";
-import type { CollectionConfig, CollectionSlug, Document, GlobalSlug, PayloadRequest } from 'payload';
+import type { CollectionConfig, CollectionSlug, Document, GlobalConfig, GlobalSlug, PayloadRequest } from 'payload';
 import { toWords } from 'payload';
 import { payloadCrowdinSyncDocumentFilesApi } from "./document";
 import { getCollectionConfig } from "../helpers";
@@ -116,6 +116,7 @@ export class filesApiByDocument {
         await this.findOrCreateCollectionDirectory({
           collectionSlug: this.global ? "globals" : this.collectionSlug,
         });
+        
 
       const parent = isCrowdinArticleDirectory(this.parent) ? this.parent : this.parent && await this.req.payload.findByID({
           collection: "crowdin-article-directories",
@@ -125,11 +126,16 @@ export class filesApiByDocument {
 
       // Create article directory on Crowdin
       const name = this.global ? this.collectionSlug : this.document.id
-      const collectionConfig = this.global ? undefined : getCollectionConfig(
-        this.collectionSlug,
-        false,
-        this.req.payload
-      )
+      let collectionConfig: CollectionConfig | GlobalConfig;
+      try {
+        collectionConfig = getCollectionConfig(
+          this.collectionSlug,
+          false,
+          this.req.payload
+        )
+      } catch (error) {
+        console.log(error)
+      }
       const useAsTitle = (collectionConfig as CollectionConfig)?.admin?.useAsTitle
 
       crowdinPayloadArticleDirectory = await this.crowdinFindOrCreateDirectory({

--- a/plugin/src/lib/api/files/document.ts
+++ b/plugin/src/lib/api/files/document.ts
@@ -1,7 +1,7 @@
 import { PluginOptions } from '../../index';
 import { payloadCrowdinSyncFilesApi } from ".";
 import { CrowdinArticleDirectory, CrowdinFile } from '../../payload-types';
-import { BlocksField as BlockField, CollectionConfig, Document, GlobalConfig, PayloadRequest, RichTextField } from 'payload';
+import { BlocksField as BlockField, CollectionConfig, Document, Field, GlobalConfig, PayloadRequest, RichTextField } from 'payload';
 
 import { isEmpty } from 'es-toolkit/compat';
 import {
@@ -257,7 +257,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
     // brittle check for Lexical value - improve this detection. Type check? Anything from Payload to indicate the type?
     let blockContent, blockConfig: BlockField | undefined
     const isLexical = Object.prototype.hasOwnProperty.call(value, "root")
-    
+
     if (isLexical) {
       const field = findField({
         dotNotation: name,
@@ -272,6 +272,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
         // no need to detect change - this has already been done on the field's JSON object
         blockContent = value && extractLexicalBlockContent(value.root)
         blockConfig = editorConfig && getLexicalBlockFields(editorConfig)
+
         if (blockContent && blockContent.length > 0 && blockConfig) {
           await this.createLexicalBlocks({
             collection,
@@ -343,6 +344,9 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
       },
     );
 
+    /**
+     * Here's the issue, the code pauses/stops here.
+     */
     const filesApi = await apiByDocument.get()
       const fieldName = `blocks`
       const currentCrowdinJsonData = buildCrowdinJsonObject({
@@ -353,6 +357,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
           {
             name: fieldName,
             type: 'blocks',
+            localized: true,
             blocks: blockConfig.blocks,
           }
         ],
@@ -366,12 +371,12 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
           {
             name: fieldName,
             type: 'blocks',
+            localized: true,
             blocks: blockConfig.blocks,
           }
         ],
         isLocalized: reLocalizeField, // ignore localized attribute
       });
-
     await filesApi.createOrUpdateJsonFile({
       fileData: currentCrowdinJsonData,
       fileName: fieldName,
@@ -387,7 +392,8 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
             {
               name: fieldName,
               type: 'blocks',
-              blocks: blockConfig ? blockConfig.blocks : [],
+              localized: true,
+              blocks: blockConfig ? blockConfig.blocks : []
             }
           ],
         },

--- a/plugin/src/lib/api/files/index.ts
+++ b/plugin/src/lib/api/files/index.ts
@@ -111,11 +111,16 @@ export class payloadCrowdinSyncFilesApi {
   }
 
   async getArticleDirectory(documentId: string): Promise<CrowdinArticleDirectory | undefined> {
-    const result = await getArticleDirectory({
-      documentId,
-      payload: this.req.payload,
-      req: this.req
-    });
+    let result = undefined
+    try {
+      result = await getArticleDirectory({
+        documentId,
+        payload: this.req.payload,
+        req: this.req
+      });
+    } catch (error) {
+      console.log(error)
+    }
     return result as CrowdinArticleDirectory | undefined;
   }
 

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -13,6 +13,9 @@ export const getCollectionConfig = (
     | SanitizedGlobalConfig
     | SanitizedCollectionConfig
     | undefined;
+  if (!collection || !global) {
+    return undefined
+  }
   if (global) {
     collectionConfig = payload.config.globals.find(
       (col: GlobalConfig) => col.slug === collection
@@ -161,9 +164,14 @@ export async function getFileByDocumentID(
   payload: Payload,
   req?: PayloadRequest,
 ): Promise<CrowdinFile> {
-  const articleDirectory = await getArticleDirectory({
-    documentId, payload, req,
-  });
+  let articleDirectory = undefined
+  try {
+    articleDirectory = await getArticleDirectory({
+      documentId, payload, req,
+    });
+  } catch (error) {
+    console.log(error)
+  }  
   return getFile(name, `${articleDirectory?.id}`, payload, req);
 }
 
@@ -178,13 +186,18 @@ export async function getFilesByDocumentID({
   parent?: CrowdinArticleDirectory,
   req?: PayloadRequest
 }): Promise<CrowdinFile[]> {
-  const articleDirectory = await getArticleDirectory({
-    documentId: `${documentId}`,
-    payload,
-    allowEmpty: false,
-    parent,
-    req,
-  });
+  let articleDirectory = undefined
+  try {
+    articleDirectory = await getArticleDirectory({
+      documentId: `${documentId}`,
+      payload,
+      allowEmpty: false,
+      parent,
+      req,
+    });
+  } catch (error) {
+    console.log(error)
+  }
   if (!articleDirectory) {
     // tests call this function to make sure files are deleted
     return [];

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -75,6 +75,27 @@ export async function getArticleDirectory(
     : undefined;
 }
 
+export async function getLexicalFieldArticleDirectories({
+  payload,
+  parent,
+  req,
+}: {
+  payload: Payload,
+  parent?: CrowdinArticleDirectory | null | string,
+  req?: PayloadRequest,
+}) {
+  const query = await payload.find({
+    collection: "crowdin-article-directories",
+    where: {
+      parent: {
+        equals: isCrowdinArticleDirectory(parent) ? parent?.id : parent,
+      }
+    },
+    req,
+  });
+  return query.docs
+}
+
 export async function getLexicalFieldArticleDirectory({
   payload,
   parent,

--- a/plugin/src/lib/api/helpers.ts
+++ b/plugin/src/lib/api/helpers.ts
@@ -13,7 +13,7 @@ export const getCollectionConfig = (
     | SanitizedGlobalConfig
     | SanitizedCollectionConfig
     | undefined;
-  if (!collection || !global) {
+  if (!collection && !global) {
     return undefined
   }
   if (global) {

--- a/plugin/src/lib/api/translations.ts
+++ b/plugin/src/lib/api/translations.ts
@@ -272,11 +272,16 @@ export class payloadCrowdinSyncTranslationsApi {
       });
     }
 
-    const collectionConfig = this.getCollectionConfig(collection, global);
+    let collectionConfig = undefined
+    try {
+      collectionConfig = this.getCollectionConfig(collection, global);
+    } catch (error) {
+      console.log(error)
+    }
 
-    const localizedFields = getLocalizedFields({
+    const localizedFields = collectionConfig ? getLocalizedFields({
       fields: collectionConfig.fields,
-    });
+    }) : [];
 
     // build crowdin json object
     const crowdinJsonObject = buildCrowdinJsonObject({
@@ -320,11 +325,16 @@ export class payloadCrowdinSyncTranslationsApi {
     locale,
     global = false,
   }: IgetLatestDocumentTranslation) {
-    const collectionConfig = this.getCollectionConfig(collection, global);
+    let collectionConfig = undefined
+    try {
+      collectionConfig = this.getCollectionConfig(collection, global);
+    } catch (error) {
+      console.log(error)
+    }
 
-    const localizedFields = getLocalizedFields({
+    const localizedFields = collectionConfig ? getLocalizedFields({
       fields: collectionConfig.fields,
-    });
+    }) : [];
 
     if (!localizedFields) {
       return { message: "no localized fields" };
@@ -366,21 +376,23 @@ export class payloadCrowdinSyncTranslationsApi {
     });
 
     // Add required fields if not present
-    const requiredFieldSlugs = getFieldSlugs(
-      getLocalizedRequiredFields(collectionConfig)
-    );
-    if (requiredFieldSlugs.length > 0) {
-      const currentTranslations = await this.getCurrentDocumentTranslation({
-        doc: doc,
-        collection: collection,
-        locale: locale,
-        global,
-      });
-      requiredFieldSlugs.forEach((slug) => {
-        if (!Object.prototype.hasOwnProperty.call(docTranslations, slug)) {
-          docTranslations[slug] = currentTranslations[slug];
-        }
-      });
+    if (collectionConfig) {
+      const requiredFieldSlugs = getFieldSlugs(
+        getLocalizedRequiredFields(collectionConfig)
+      );
+      if (requiredFieldSlugs.length > 0) {
+        const currentTranslations = await this.getCurrentDocumentTranslation({
+          doc: doc,
+          collection: collection,
+          locale: locale,
+          global,
+        });
+        requiredFieldSlugs.forEach((slug) => {
+          if (!Object.prototype.hasOwnProperty.call(docTranslations, slug)) {
+            docTranslations[slug] = currentTranslations[slug];
+          }
+        });
+      }
     }
     return docTranslations;
   }

--- a/plugin/src/lib/index.ts
+++ b/plugin/src/lib/index.ts
@@ -9,6 +9,7 @@ import {
   getFilesByDocumentID,
   getArticleDirectory,
   getLexicalFieldArticleDirectory,
+  getLexicalFieldArticleDirectories,
 } from "./api/helpers"
 // translations api
 import { payloadCrowdinSyncTranslationsApi } from "./api/translations";
@@ -41,5 +42,6 @@ export {
   mockCrowdinClient,
   extractLexicalBlockContent,
   getLexicalFieldArticleDirectory,
+  getLexicalFieldArticleDirectories,
   getRelationshipId,
 };


### PR DESCRIPTION

## Details

## Scenario:

Blocks field (`layout`) → Block (`basicBlockLexical`) → Lexical field (localized, `content`) → <ins>Embedded block (`highlight`) → Lexical field (`content`) → Embedded block (`featureList`)</ins>

The <ins>underlined</ins> fields are not sent for localization.

The child directory `lex.layout.688dd685258ffa0224ea6daa.basicBlockLexical.content` is created but no Crowdin files are placed within it.

##

- Failing test created to start the investigation.
- Issue was difficult to diagnose due to uncaught exceptions. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw terminates with no feedback if it is not in a `try ... catch` block.
- Resolved the thrown error. Added `try ... catch` blocks in multiple places where exceptions are thrown to try and mitigate the diagnosis issue in the future. 
- Related: https://github.com/thompsonsj/payload-crowdin-sync/issues/90.

