### PR TITLE
feat: add row field localization support

### DIFF
--- a/plugin/src/lib/utilities/getCollapsibleLocalizedFields.spec.ts
+++ b/plugin/src/lib/utilities/getCollapsibleLocalizedFields.spec.ts
@@ -1,5 +1,5 @@
 import type { GlobalConfig } from 'payload';
-import { getCollapsibleLocalizedFields } from '.';
+import { getCollapsibleLocalizedFields, getRowLocalizedFields } from '.';
 
 describe('fn: getCollapsibleLocalizedFields', () => {
   it('includes only localized fields from a collapsible field', () => {
@@ -47,6 +47,53 @@ describe('fn: getCollapsibleLocalizedFields', () => {
       },
     ];
     expect(getCollapsibleLocalizedFields({ fields: global.fields })).toEqual(
+      expected,
+    );
+  });
+
+  it('includes only localized fields from a row field', () => {
+    const global: GlobalConfig = {
+      slug: 'global',
+      fields: [
+        {
+          name: 'textLocalizedField',
+          type: 'text',
+          localized: true,
+        },
+        {
+          type: 'row',
+          fields: [
+            {
+              name: 'textLocalizedFieldInRowField',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'textNonLocalizedFieldInRowField',
+              type: 'text',
+            },
+            {
+              name: 'textareaLocalizedFieldInRowField',
+              type: 'textarea',
+              localized: true,
+            },
+          ],
+        },
+      ],
+    };
+    const expected = [
+      {
+        name: 'textLocalizedFieldInRowField',
+        type: 'text',
+        localized: true,
+      },
+      {
+        name: 'textareaLocalizedFieldInRowField',
+        type: 'textarea',
+        localized: true,
+      },
+    ];
+    expect(getRowLocalizedFields({ fields: global.fields })).toEqual(
       expected,
     );
   });

--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -4,6 +4,7 @@ import type {
   CollectionConfig,
   Field,
   GlobalConfig,
+  RowField,
 } from 'payload';
 import deepEqual from 'deep-equal';
 import { FieldWithName, type CrowdinHtmlObject } from '../types';
@@ -184,7 +185,9 @@ export const getLocalizedFields = ({
     })
     .filter(
       (field) =>
-        (field as any).type !== 'collapsible' && (field as any).type !== 'tabs',
+        (field as any).type !== 'collapsible' &&
+        (field as any).type !== 'tabs' &&
+        (field as any).type !== 'row',
     ),
   ...convertTabs({
     fields,
@@ -199,6 +202,8 @@ export const getLocalizedFields = ({
   }),
   // recursion for collapsible field - flatten results into the returned array
   ...getCollapsibleLocalizedFields({ fields, type, isLocalized }),
+  // recursion for row field - flatten results into the returned array
+  ...getRowLocalizedFields({ fields, type, isLocalized }),
 ];
 
 export const getCollapsibleLocalizedFields = ({
@@ -215,6 +220,25 @@ export const getCollapsibleLocalizedFields = ({
     .flatMap((field) =>
       getLocalizedFields({
         fields: (field as CollapsibleField).fields,
+        type,
+        isLocalized,
+      }),
+    );
+
+export const getRowLocalizedFields = ({
+  fields,
+  type,
+  isLocalized = isLocalizedField,
+}: {
+  fields: Field[];
+  type?: 'json' | 'html';
+  isLocalized?: IsLocalized;
+}): any[] =>
+  fields
+    .filter((field) => field.type === 'row')
+    .flatMap((field) =>
+      getLocalizedFields({
+        fields: (field as RowField).fields,
         type,
         isLocalized,
       }),


### PR DESCRIPTION
- Added getRowLocalizedFields utility to extract localized fields from row type fields
- Updated getLocalizedFields to filter out row fields from top level and process them separately
- Added unit tests to verify localized field extraction from row fields
- Extended type imports to include RowField type for proper typing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended localization extraction to properly handle localized fields within row-type field structures, improving content management capabilities.

* **Tests**
  * Added comprehensive test coverage for row-field localization extraction, ensuring localized content within rows is correctly identified and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->