### PR TITLE
fix(bydocument): article directory not found prevents delete

### DIFF
--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -12,9 +12,12 @@ import type {
   PayloadRequest,
 } from 'payload';
 import { toWords } from 'payload';
-import { payloadCrowdinSyncDocumentFilesApi } from './document';
+import {
+  payloadCrowdinSyncDocumentFilesApi,
+} from './document';
 import {
   findRootArticleDirectoryPolymorphic,
+  getArticleDirectory,
   getCollectionConfig,
 } from '../helpers';
 
@@ -117,13 +120,92 @@ export class filesApiByDocument {
     );
   }
 
+  /**
+   * Resolve an existing article directory without creating one.
+   * Used on delete so orphaned `crowdinArticleDirectory` refs do not block removal.
+   */
+  async resolveExistingArticleDirectory(): Promise<
+    CrowdinArticleDirectory | undefined
+  > {
+    const documentId = this.global
+      ? (this.collectionSlug as string)
+      : this.document.id;
+
+    let crowdinPayloadArticleDirectory =
+      await findRootArticleDirectoryPolymorphic({
+        payload: this.req.payload,
+        req: this.req,
+        documentId,
+        rootLookup: {
+          collectionSlug: this.collectionSlug as string,
+          global: this.global,
+        },
+      });
+
+    if (!crowdinPayloadArticleDirectory && this.document.crowdinArticleDirectory) {
+      const ref = this.document.crowdinArticleDirectory;
+      if (isCrowdinArticleDirectory(ref) || ref?.id) {
+        crowdinPayloadArticleDirectory = ref as CrowdinArticleDirectory;
+      } else {
+        try {
+          crowdinPayloadArticleDirectory = (await this.req.payload.findByID({
+            collection: 'crowdin-article-directories',
+            id: ref,
+            req: this.req,
+          })) as CrowdinArticleDirectory;
+        } catch {
+          // Orphaned reference — nothing to clean up on Crowdin.
+        }
+      }
+    }
+
+    if (!crowdinPayloadArticleDirectory) {
+      crowdinPayloadArticleDirectory = (await getArticleDirectory({
+        documentId,
+        payload: this.req.payload,
+        req: this.req,
+        allowEmpty: true,
+        rootLookup: {
+          collectionSlug: this.collectionSlug as string,
+          global: this.global,
+        },
+      })) as CrowdinArticleDirectory | undefined;
+    }
+
+    return crowdinPayloadArticleDirectory;
+  }
+
+  /**
+   * Remove Crowdin files and the article directory when one exists.
+   * Skips cleanup when no directory is found (including orphaned refs).
+   */
+  async deleteCrowdinAssetsIfPresent(): Promise<void> {
+    const articleDirectory = await this.resolveExistingArticleDirectory();
+    if (!articleDirectory) {
+      return;
+    }
+
+    this.articleDirectory = articleDirectory;
+    const filesApi = new payloadCrowdinSyncDocumentFilesApi(
+      {
+        document: this.document,
+        articleDirectory: this.articleDirectory,
+        collectionSlug: this.collectionSlug,
+        global: this.global,
+      },
+      this.pluginOptions,
+      this.req,
+    );
+
+    await filesApi.deleteFilesAndDirectory();
+  }
+
   async assertArticleDirectoryProvided() {
     if (!this.articleDirectory || this.articleDirectory.id === `undefined`) {
       this.articleDirectory = await this.findOrCreateArticleDirectory();
     }
   }
 
-  /** this is where the problem lies? */
   async findOrCreateArticleDirectory(): Promise<CrowdinArticleDirectory> {
     let crowdinPayloadArticleDirectory: CrowdinArticleDirectory | undefined;
 

--- a/plugin/src/lib/hooks/collections/afterDelete.spec.ts
+++ b/plugin/src/lib/hooks/collections/afterDelete.spec.ts
@@ -97,8 +97,7 @@ describe('getAfterDeleteHook', () => {
   });
 
   it('returns doc without cleanup when token is unset outside test mode', async () => {
-    const previousNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const hook = getAfterDeleteHook({
       collection: minimalCollection,
@@ -114,6 +113,6 @@ describe('getAfterDeleteHook', () => {
     expect(result).toBe(doc);
     expect(deleteCrowdinAssetsIfPresent).not.toHaveBeenCalled();
 
-    process.env.NODE_ENV = previousNodeEnv;
+    vi.unstubAllEnvs();
   });
 });

--- a/plugin/src/lib/hooks/collections/afterDelete.spec.ts
+++ b/plugin/src/lib/hooks/collections/afterDelete.spec.ts
@@ -1,0 +1,119 @@
+import { getAfterDeleteHook } from './afterDelete';
+import { pluginOptions } from '../../api/mock/plugin-options';
+import type { CollectionConfig } from 'payload';
+
+const deleteCrowdinAssetsIfPresent = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../api/files/by-document', () => ({
+  filesApiByDocument: class MockFilesApiByDocument {
+    deleteCrowdinAssetsIfPresent = deleteCrowdinAssetsIfPresent;
+  },
+}));
+
+const minimalCollection: CollectionConfig = {
+  slug: 'testimonials',
+  fields: [
+    {
+      name: 'quote',
+      type: 'text',
+      localized: true,
+    },
+    {
+      name: 'translateWithCrowdin',
+      type: 'checkbox',
+    },
+  ],
+};
+
+const doc = {
+  id: '659489f7b6d58cf7699eb456',
+  quote: 'Great product',
+  translateWithCrowdin: false,
+};
+
+function buildReq() {
+  return {
+    payload: {
+      collections: {
+        testimonials: {
+          config: minimalCollection,
+        },
+      },
+    },
+  } as any;
+}
+
+describe('getAfterDeleteHook', () => {
+  beforeEach(() => {
+    deleteCrowdinAssetsIfPresent.mockClear();
+  });
+
+  it('skips Crowdin cleanup when the collection condition is not met', async () => {
+    const hook = getAfterDeleteHook({
+      collection: minimalCollection,
+      pluginOptions: {
+        ...pluginOptions,
+        collections: [
+          {
+            slug: 'testimonials',
+            condition: ({ doc: d }) => Boolean(d.translateWithCrowdin),
+          },
+        ],
+      },
+    });
+
+    const result = await hook({
+      doc,
+      req: buildReq(),
+      collection: minimalCollection,
+    } as any);
+
+    expect(result).toBe(doc);
+    expect(deleteCrowdinAssetsIfPresent).not.toHaveBeenCalled();
+  });
+
+  it('runs Crowdin cleanup when the collection condition is met', async () => {
+    const hook = getAfterDeleteHook({
+      collection: minimalCollection,
+      pluginOptions: {
+        ...pluginOptions,
+        collections: [
+          {
+            slug: 'testimonials',
+            condition: ({ doc: d }) => Boolean(d.translateWithCrowdin),
+          },
+        ],
+      },
+    });
+
+    const result = await hook({
+      doc: { ...doc, translateWithCrowdin: true },
+      req: buildReq(),
+      collection: minimalCollection,
+    } as any);
+
+    expect(result).toEqual({ ...doc, translateWithCrowdin: true });
+    expect(deleteCrowdinAssetsIfPresent).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns doc without cleanup when token is unset outside test mode', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    const hook = getAfterDeleteHook({
+      collection: minimalCollection,
+      pluginOptions: { ...pluginOptions, token: '' },
+    });
+
+    const result = await hook({
+      doc,
+      req: buildReq(),
+      collection: minimalCollection,
+    } as any);
+
+    expect(result).toBe(doc);
+    expect(deleteCrowdinAssetsIfPresent).not.toHaveBeenCalled();
+
+    process.env.NODE_ENV = previousNodeEnv;
+  });
+});

--- a/plugin/src/lib/hooks/collections/afterDelete.ts
+++ b/plugin/src/lib/hooks/collections/afterDelete.ts
@@ -1,24 +1,28 @@
 import type {
   CollectionAfterDeleteHook,
+  CollectionConfig,
   CollectionSlug,
   GlobalSlug,
 } from 'payload';
 import { PluginOptions } from '../../types';
 import { filesApiByDocument } from '../../api/files/by-document';
+import { isCrowdinActive } from '../../api/helpers';
+import { getLocalizedFields } from '../../utilities';
 
 interface CommonArgs {
   pluginOptions: PluginOptions;
 }
 
-interface Args extends CommonArgs {}
+interface Args extends CommonArgs {
+  collection: CollectionConfig;
+}
 
 export const getAfterDeleteHook =
-  ({ pluginOptions }: Args): CollectionAfterDeleteHook =>
+  ({ collection, pluginOptions }: Args): CollectionAfterDeleteHook =>
   async ({
     req, // full express request
-    id, // id of document to delete
     doc, // deleted document
-    collection,
+    collection: collectionFromHook,
   }) => {
     /**
      * Abort if token not set and not in test mode
@@ -27,18 +31,49 @@ export const getAfterDeleteHook =
       return doc;
     }
 
+    const sanitizedCollection =
+      req.payload.collections[collection.slug]?.config ??
+      collectionFromHook;
+
+    if (!sanitizedCollection) {
+      return doc;
+    }
+
     /**
-     * Initialize Crowdin client sourceFilesApi
+     * Abort if a document condition has been set and returns false
      */
-    const global = false; // delete only on collections by nature.
+    const active = isCrowdinActive({
+      doc,
+      slug: sanitizedCollection.slug,
+      global: false,
+      pluginOptions,
+    });
+
+    if (!active) {
+      return doc;
+    }
+
+    const localizedFields = getLocalizedFields({
+      fields: sanitizedCollection.fields,
+    });
+
+    if (localizedFields.length === 0) {
+      return doc;
+    }
+
+    /**
+     * Delete Crowdin assets only when an article directory already exists.
+     * Do not create directories on delete (orphaned refs must not block deletion).
+     */
+    const global = false;
     const apiByDocument = new filesApiByDocument({
       document: doc,
-      collectionSlug: collection.slug as CollectionSlug | GlobalSlug,
+      collectionSlug: sanitizedCollection.slug as CollectionSlug | GlobalSlug,
       global,
       pluginOptions,
       req: req,
     });
-    const filesApi = await apiByDocument.get();
 
-    await filesApi.deleteFilesAndDirectory();
+    await apiByDocument.deleteCrowdinAssetsIfPresent();
+    return doc;
   };

--- a/plugin/src/lib/plugin.ts
+++ b/plugin/src/lib/plugin.ts
@@ -215,6 +215,7 @@ export const crowdinSync =
                 afterDelete: [
                   ...(existingCollection.hooks?.afterDelete || []),
                   getAfterDeleteHook({
+                    collection: existingCollection,
                     pluginOptions,
                   }),
                 ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer Crowdin asset cleanup on document deletion: deletion now only runs when a resolved collection config, localization, and credentials are present, and will not create directories when deleting.
* **Refactor**
  * Deletion hook now uses the resolved collection configuration to decide whether to run cleanup.
* **Tests**
  * Added tests verifying cleanup runs, is skipped for falsey conditions, and respects missing credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thompsonsj/payload-crowdin-sync/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->