### PR TITLE
refactor(api): create plan and first pass

### DIFF
--- a/docs-site/docs/repo/refactoring.md
+++ b/docs-site/docs/repo/refactoring.md
@@ -1,0 +1,100 @@
+# API layer refactoring plan
+
+This document describes the planned refactoring of `plugin/src/lib/api`. The goal is cleaner method boundaries, strong interfaces backing class properties, and a module layout that makes it straightforward to add adapters for other translation APIs (Phrase, Lokalise, etc.).
+
+## Context
+
+The `api/` directory has four main areas:
+
+| File | Role |
+|------|------|
+| `helpers.ts` | Payload CMS query utilities |
+| `translations.ts` | Fetch translations from Crowdin and write to Payload |
+| `files/index.ts` | Base Crowdin file CRUD |
+| `files/document.ts` | Document-scoped file operations (extends index) |
+| `files/by-document.ts` | Directory orchestration and find-or-create logic |
+
+---
+
+## Items
+
+### 1. Extract name conflict resolution utility ✅
+
+**Problem:** The same Crowdin "name already exists" error detection and recovery pattern is duplicated in three places:
+- `files/index.ts` — `crowdinCreateFile()` (checks `file.name.is_already_exists`)
+- `files/by-document.ts` — `findOrCreateCollectionDirectory()` (checks `directory.name.is_already_exists`)
+- `files/by-document.ts` — `crowdinFindOrCreateDirectory()` (same as above)
+
+Each copy has slightly different string checks, meaning fixes diverge over time.
+
+**Fix:** Export `isCrowdinNameConflictError(error: unknown): boolean` from `files/index.ts`. Covers both `file.name.*` and `directory.name.*` error keys plus the plain-string `'Name must be unique'` fallback. All three call sites use this instead of inline detection.
+
+---
+
+### 2. Named constructor parameter interfaces ✅
+
+**Problem:** `filesApiByDocument` and `payloadCrowdinSyncDocumentFilesApi` both define their constructor argument as an anonymous inline type. Class properties and constructor params describe the same shape twice with no shared contract.
+
+**Fix:** Extract named interfaces for constructor options:
+- `IfilesApiByDocumentOptions` in `files/by-document.ts`
+- `IpayloadCrowdinSyncDocumentFilesApiOptions` in `files/document.ts`
+
+Constructor signatures reference the interface. This gives a single place to update when fields change and makes it explicit what `get()` and similar factory methods need.
+
+---
+
+### 3. Split `getTranslation()` into strategy methods
+
+**Problem:** `translations.ts:getTranslation()` is 154 lines handling four distinct cases in one method:
+1. JSON fields via Crowdin API
+2. HTML → Slate conversion
+3. HTML → Lexical conversion (including nested block lookup)
+4. Error/fallback return
+
+**Fix:** Introduce private methods:
+- `getJsonTranslation()` — parse JSON, return object
+- `getSlateTranslation()` — fetch HTML, convert to Slate
+- `getLexicalTranslation()` — fetch HTML, resolve lexical blocks, convert
+
+`getTranslation()` becomes a thin dispatcher that calls the right method based on `file.type` and editor config. These are the natural seam points for a future adapter pattern.
+
+---
+
+### 4. Isolate Lexical block handling
+
+**Problem:** Lexical-specific logic is spread across `document.ts`, `translations.ts`, and `by-document.ts`:
+- Hardcoded `'mock-collection-for-lexical-blocks'` slug in `document.ts:512`
+- `fieldName = 'blocks'` override in `document.ts:472`
+- `lexicalBlockFolderPrefix` threaded through both files and translations
+- `createLexicalBlocks()` recursively instantiates a new `filesApiByDocument`, creating a fragile cycle
+
+**Fix:** Extract to `files/lexical-blocks.ts` with a clean interface. This module owns the folder naming, the mock collection config, the block content extraction, and the recursive sync. Both `document.ts` and `translations.ts` delegate to it.
+
+---
+
+### 5. Decompose `findOrCreateArticleDirectory()` and `createFile()`
+
+**Problem:**
+- `by-document.ts:findOrCreateArticleDirectory()` — 128 lines, four nested lookup strategies
+- `document.ts:createFile()` — 137 lines, five possible database writes, two duplicate-detection paths
+
+**Fix:**
+- `findOrCreateArticleDirectory()` → extract each lookup strategy to a named private method (`findByPolymorphicLink`, `findByLegacyField`, `findInPayload`, `createNew`), making the orchestration readable at a glance
+- `createFile()` → separate `syncExistingPayloadFile()` (handles found-in-payload case) and `syncExistingCrowdinFile()` (handles `revisionId > 1` case) from the main happy path
+
+---
+
+### 6. Unified polymorphic resolver
+
+**Problem:** Three separate locations implement article directory lookup with different fallback orderings:
+- `helpers.ts:findRootArticleDirectoryPolymorphic()`
+- `by-document.ts:resolveExistingArticleDirectory()` (four fallbacks)
+- `by-document.ts:findOrCreateArticleDirectory()` (inline strategies)
+
+**Fix:** Single resolver in `helpers.ts` with a consistent strategy ordering (polymorphic → legacy field → Payload query → optional create). All callers use it.
+
+---
+
+## Future: adapter pattern
+
+Once items 3 and 4 are complete, the translation strategies (`getJsonTranslation`, `getSlateTranslation`, `getLexicalTranslation`) and the files layer (`createOrUpdateFile`, etc.) can be extracted behind interfaces, making it possible to implement a Phrase or Lokalise adapter that satisfies the same contracts without touching the orchestration layer.

--- a/docs-site/docs/repo/refactoring.md
+++ b/docs-site/docs/repo/refactoring.md
@@ -4,7 +4,7 @@ This document describes the planned refactoring of `plugin/src/lib/api`. The goa
 
 ## Context
 
-The `api/` directory has four main areas:
+The `api/` directory has five main areas:
 
 | File | Role |
 |------|------|

--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -12,6 +12,7 @@ import type {
   PayloadRequest,
 } from 'payload';
 import { toWords } from 'payload';
+import { isCrowdinNameConflictError } from '.';
 import {
   payloadCrowdinSyncDocumentFilesApi,
 } from './document';
@@ -33,6 +34,16 @@ import {
 
 interface IfindOrCreateCollectionDirectory {
   collectionSlug: CollectionSlug | 'globals';
+}
+
+export interface IfilesApiByDocumentOptions {
+  document: Document;
+  collectionSlug: CollectionSlug | GlobalSlug;
+  global: boolean;
+  pluginOptions: PluginOptions;
+  req: PayloadRequest;
+  /** Lexical field blocks use their own CrowdinArticleDirectory. */
+  parent?: CrowdinArticleDirectory['parent'];
 }
 
 /**
@@ -65,15 +76,7 @@ export class filesApiByDocument {
     pluginOptions,
     req,
     parent,
-  }: {
-    document: Document;
-    collectionSlug: CollectionSlug | GlobalSlug;
-    global: boolean;
-    pluginOptions: PluginOptions;
-    req: PayloadRequest;
-    /** Lexical field blocks use their own CrowdinArticleDirectory. */
-    parent?: CrowdinArticleDirectory['parent'];
-  }) {
+  }: IfilesApiByDocumentOptions) {
     // credentials
     const credentials: Credentials = {
       token: pluginOptions.token,
@@ -378,15 +381,7 @@ export class filesApiByDocument {
         // In integration tests, the Crowdin collection directory can already exist in the remote mock
         // (or multiple test files may race to create it). If Crowdin rejects due to name uniqueness,
         // recover by fetching the existing directory and continuing.
-        const isNameConflictError =
-          createError?.error?.errors?.some(
-            (e: any) =>
-              e?.error?.key === 'directory.name.is_already_exists' ||
-              e?.error?.key === 'directory.name' ||
-              String(createError).includes('Name must be unique'),
-          ) || String(createError).includes('Name must be unique');
-
-        if (!isNameConflictError) {
+        if (!isCrowdinNameConflictError(createError)) {
           throw createError;
         }
 
@@ -547,16 +542,7 @@ export class filesApiByDocument {
         });
         return result as CrowdinArticleDirectory;
       } catch (createError: any) {
-        // Check if this is a "name must be unique" error
-        const isNameConflictError =
-          createError?.error?.errors?.some(
-            (e: any) =>
-              e?.error?.key === 'directory.name.is_already_exists' ||
-              e?.error?.key === 'directory.name' ||
-              String(createError).includes('Name must be unique'),
-          ) || String(createError).includes('Name must be unique');
-
-        if (isNameConflictError) {
+        if (isCrowdinNameConflictError(createError)) {
           if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
             console.log(
               `Directory "${name}" already exists on Crowdin in parent directory ${parentDirectoryId}. Attempting to find and sync existing directory...`,

--- a/plugin/src/lib/api/files/document.ts
+++ b/plugin/src/lib/api/files/document.ts
@@ -41,6 +41,13 @@ interface IupdateOrCreateFile {
   sourceBlocks?: unknown[];
 }
 
+export interface IpayloadCrowdinSyncDocumentFilesApiOptions {
+  document: Document;
+  articleDirectory: CrowdinArticleDirectory;
+  collectionSlug: CollectionSlug | 'globals';
+  global: boolean;
+}
+
 export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesApi {
   document: Document;
   articleDirectory: CrowdinArticleDirectory;
@@ -53,12 +60,7 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
       articleDirectory,
       collectionSlug,
       global,
-    }: {
-      document: Document;
-      articleDirectory: CrowdinArticleDirectory;
-      collectionSlug: CollectionSlug | 'globals';
-      global: boolean;
-    },
+    }: IpayloadCrowdinSyncDocumentFilesApiOptions,
     pluginOptions: PluginOptions,
     req: PayloadRequest,
   ) {

--- a/plugin/src/lib/api/files/document.ts
+++ b/plugin/src/lib/api/files/document.ts
@@ -45,7 +45,7 @@ export interface IpayloadCrowdinSyncDocumentFilesApiOptions {
   document: Document;
   articleDirectory: CrowdinArticleDirectory;
   collectionSlug: CollectionSlug | 'globals';
-  global: boolean;
+  global?: boolean;
 }
 
 export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesApi {

--- a/plugin/src/lib/api/files/index.ts
+++ b/plugin/src/lib/api/files/index.ts
@@ -17,6 +17,23 @@ import {
   UploadStorage,
 } from '@crowdin/crowdin-api-client';
 
+/**
+ * Returns true when a Crowdin API error indicates a name uniqueness conflict on
+ * either a file (`file.name.*`) or a directory (`directory.name.*`).
+ */
+export function isCrowdinNameConflictError(error: unknown): boolean {
+  return (
+    (error as any)?.error?.errors?.some(
+      (e: any) =>
+        e?.error?.key === 'file.name.is_already_exists' ||
+        e?.error?.key === 'file.name' ||
+        e?.error?.key === 'directory.name.is_already_exists' ||
+        e?.error?.key === 'directory.name' ||
+        String(error).includes('Name must be unique'),
+    ) || String(error).includes('Name must be unique')
+  );
+}
+
 interface IcreateOrUpdateFile {
   name: string;
   fileData: string | object;
@@ -140,16 +157,7 @@ export class payloadCrowdinSyncFilesApi {
       );
       return file;
     } catch (error: any) {
-      // Check if this is a "name must be unique" error
-      const isNameConflictError =
-        error?.error?.errors?.some(
-          (e: any) =>
-            e?.error?.key === 'file.name.is_already_exists' ||
-            e?.error?.key === 'file.name' ||
-            String(error).includes('Name must be unique'),
-        ) || String(error).includes('Name must be unique');
-
-      if (isNameConflictError) {
+      if (isCrowdinNameConflictError(error)) {
         if (verbose) {
           console.log(
             `File "${fullFileName}" already exists on Crowdin in directory ${directoryId}. Attempting to find and sync existing file...`,


### PR DESCRIPTION
**Plan doc** written to `docs-site/docs/repo/refactoring.md` — covers all 6 items from the analysis, marks items 1 and 2 as done, includes the adapter-pattern future section.

### Items 1 & 2 — name conflict extraction + constructor interfaces

**Item 1 — name conflict extraction:**
- `files/index.ts` — added exported `isCrowdinNameConflictError(error)` that covers both `file.name.*` and `directory.name.*` Crowdin error keys plus the plain-string fallback
- All three call sites in `index.ts` and `by-document.ts` now use it instead of duplicated inline detection

**Item 2 — named constructor interfaces:**
- `files/by-document.ts` — `IfilesApiByDocumentOptions` (exported, so callers building the options object can type-check against it)
- `files/document.ts` — `IpayloadCrowdinSyncDocumentFilesApiOptions` (likewise exported)
- Both constructor signatures now reference the interface instead of the inline anonymous type

---

## Future: adapter pattern

Once items 3 and 4 are complete, the translation strategies (`getJsonTranslation`, `getSlateTranslation`, `getLexicalTranslation`) and the files layer (`createOrUpdateFile`, etc.) can be extracted behind interfaces, making it possible to implement a Phrase or Lokalise adapter that satisfies the same contracts without touching the orchestration layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced code organization and maintainability by extracting reusable error-detection utilities and introducing typed configuration interfaces for better code consistency.

* **Documentation**
  * Added documentation outlining planned infrastructure improvements and refactoring roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->