### PR TITLE
refactor(api): pass 2

### DIFF
--- a/docs-site/docs/repo/refactoring.md
+++ b/docs-site/docs/repo/refactoring.md
@@ -43,7 +43,7 @@ Constructor signatures reference the interface. This gives a single place to upd
 
 ---
 
-### 3. Split `getTranslation()` into strategy methods
+### 3. Split `getTranslation()` into strategy methods ✅
 
 **Problem:** `translations.ts:getTranslation()` is 154 lines handling four distinct cases in one method:
 1. JSON fields via Crowdin API
@@ -98,3 +98,23 @@ Constructor signatures reference the interface. This gives a single place to upd
 ## Future: adapter pattern
 
 Once items 3 and 4 are complete, the translation strategies (`getJsonTranslation`, `getSlateTranslation`, `getLexicalTranslation`) and the files layer (`createOrUpdateFile`, etc.) can be extracted behind interfaces, making it possible to implement a Phrase or Lokalise adapter that satisfies the same contracts without touching the orchestration layer.
+
+---
+
+## Completed work
+
+### Item 3 — split `getTranslation()` into strategy methods
+
+`translations.ts:getTranslation()` reduced from 154 lines to ~55. The dispatcher now resolves the file, fetches data from Crowdin, then calls one of:
+
+- `getJsonTranslation(data)` — `JSON.parse`, returns object
+- `getSlateTranslation(data)` — `convertHtmlToSlate` wrapper
+- `getLexicalTranslation({ data, file, fieldName, locale, editorConfig })` — resolves the lexical article directory, fetches block translations, calls `convertHtmlToLexical` with the Lexical fallback root on empty result
+
+All three are private. `getLexicalTranslation` takes `NonNullable<ReturnType<typeof getLexicalEditorConfig>>` so the caller's truthiness guard is enforced at the type level.
+
+### Items 1 & 2 — name conflict extraction + constructor interfaces
+
+- `files/index.ts` — added exported `isCrowdinNameConflictError(error)` covering `file.name.*`, `directory.name.*`, and the plain-string `'Name must be unique'` fallback. All three previous inline copies replaced.
+- `files/by-document.ts` — `IfilesApiByDocumentOptions` (exported); constructor signature updated.
+- `files/document.ts` — `IpayloadCrowdinSyncDocumentFilesApiOptions` (exported); constructor signature updated.

--- a/docs-site/docs/repo/refactoring.md
+++ b/docs-site/docs/repo/refactoring.md
@@ -98,23 +98,3 @@ Constructor signatures reference the interface. This gives a single place to upd
 ## Future: adapter pattern
 
 Once items 3 and 4 are complete, the translation strategies (`getJsonTranslation`, `getSlateTranslation`, `getLexicalTranslation`) and the files layer (`createOrUpdateFile`, etc.) can be extracted behind interfaces, making it possible to implement a Phrase or Lokalise adapter that satisfies the same contracts without touching the orchestration layer.
-
----
-
-## Completed work
-
-### Item 3 — split `getTranslation()` into strategy methods
-
-`translations.ts:getTranslation()` reduced from 154 lines to ~55. The dispatcher now resolves the file, fetches data from Crowdin, then calls one of:
-
-- `getJsonTranslation(data)` — `JSON.parse`, returns object
-- `getSlateTranslation(data)` — `convertHtmlToSlate` wrapper
-- `getLexicalTranslation({ data, file, fieldName, locale, editorConfig })` — resolves the lexical article directory, fetches block translations, calls `convertHtmlToLexical` with the Lexical fallback root on empty result
-
-All three are private. `getLexicalTranslation` takes `NonNullable<ReturnType<typeof getLexicalEditorConfig>>` so the caller's truthiness guard is enforced at the type level.
-
-### Items 1 & 2 — name conflict extraction + constructor interfaces
-
-- `files/index.ts` — added exported `isCrowdinNameConflictError(error)` covering `file.name.*`, `directory.name.*`, and the plain-string `'Name must be unique'` fallback. All three previous inline copies replaced.
-- `files/by-document.ts` — `IfilesApiByDocumentOptions` (exported); constructor signature updated.
-- `files/document.ts` — `IpayloadCrowdinSyncDocumentFilesApiOptions` (exported); constructor signature updated.

--- a/plugin/src/lib/api/translations.ts
+++ b/plugin/src/lib/api/translations.ts
@@ -515,10 +515,10 @@ export class payloadCrowdinSyncTranslationsApi {
   }
 
   /**
-   * Retrieve translations for a document field name
+   * Retrieve translations for a document field name.
    *
-   * * returns Slate object for html fields
-   * * returns all json fields if fieldName is 'fields'
+   * Resolves the Crowdin file, fetches the translated content, then dispatches
+   * to the appropriate format strategy: JSON, Slate HTML, or Lexical HTML.
    */
   // TODO refactor out fields override - replace `collection` with `fields`
   async getTranslation({
@@ -568,10 +568,7 @@ export class payloadCrowdinSyncTranslationsApi {
       return;
     }
     try {
-      const response = await this.buildTranslationFile({
-        file,
-        locale,
-      });
+      const response = await this.buildTranslationFile({ file, locale });
       if (!response) {
         if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
           console.log('lib/api/translations@getTranslation no response from buildTranslationFile');
@@ -594,72 +591,14 @@ export class payloadCrowdinSyncTranslationsApi {
             filterLocalizedFields: !crowdinArticleDirectoryId,
           }) as RichTextField;
           const editorConfig = getLexicalEditorConfig(field);
-          // isLexical?
           if (editorConfig) {
-            // retrieve the article directory created for this lexical block
-            const lexicalFieldCrowdinArticleDirectory =
-              await getLexicalFieldArticleDirectory({
-                payload: this.payload,
-                parent: file.crowdinArticleDirectory,
-                name: `${this.lexicalBlockFolderPrefix}${fieldName}`,
-                req: this.req,
-              });
-            const lexicalFieldCrowdinArticleDirectoryId = getRelationshipId(
-              lexicalFieldCrowdinArticleDirectory as any,
-            );
-
-            // get translations here and pass it to convertHtmlToLexical
-            // easier than passing `payload` and `pluginOptions` to create a new instance of the class we are in right now - keep convertHtmlToLexical focussed.
-            const blockConfig = getLexicalBlockFields(editorConfig);
-
-            const blockTranslations =
-              blockConfig && lexicalFieldCrowdinArticleDirectoryId
-                ? await this.getBlockTranslations({
-                    blockConfig,
-                    file,
-                    locale,
-                    crowdinArticleDirectoryId:
-                      lexicalFieldCrowdinArticleDirectoryId,
-                  })
-                : null;
-
-            return (
-              convertHtmlToLexical(data, blockTranslations) || {
-                root: {
-                  type: 'root',
-                  format: '',
-                  indent: 0,
-                  version: 1,
-                  children: [
-                    {
-                      children: [
-                        {
-                          detail: 0,
-                          format: 0,
-                          mode: 'normal',
-                          style: '',
-                          text: 'lexical configuration not found',
-                          type: 'text',
-                          version: 1,
-                        },
-                      ],
-                      direction: 'ltr',
-                      format: '',
-                      indent: 0,
-                      type: 'quote',
-                      version: 1,
-                    },
-                  ],
-                  direction: 'ltr',
-                },
-              }
-            );
+            return this.getLexicalTranslation({ data, file, fieldName, locale, editorConfig });
           }
         }
-        return convertHtmlToSlate(data, this.htmlToSlateConfig);
-      } else {
-        return JSON.parse(data);
+        return this.getSlateTranslation(data);
       }
+
+      return this.getJsonTranslation(data);
     } catch (error) {
       console.error(
         'getTranslation',
@@ -674,6 +613,82 @@ export class payloadCrowdinSyncTranslationsApi {
         error,
       );
     }
+  }
+
+  private getJsonTranslation(data: string): object {
+    return JSON.parse(data);
+  }
+
+  private getSlateTranslation(data: string) {
+    return convertHtmlToSlate(data, this.htmlToSlateConfig);
+  }
+
+  private async getLexicalTranslation({
+    data,
+    file,
+    fieldName,
+    locale,
+    editorConfig,
+  }: {
+    data: string;
+    file: CrowdinFile;
+    fieldName: string;
+    locale: string;
+    editorConfig: NonNullable<ReturnType<typeof getLexicalEditorConfig>>;
+  }) {
+    const lexicalFieldCrowdinArticleDirectory =
+      await getLexicalFieldArticleDirectory({
+        payload: this.payload,
+        parent: file.crowdinArticleDirectory,
+        name: `${this.lexicalBlockFolderPrefix}${fieldName}`,
+        req: this.req,
+      });
+    const lexicalFieldCrowdinArticleDirectoryId = getRelationshipId(
+      lexicalFieldCrowdinArticleDirectory as any,
+    );
+
+    const blockConfig = getLexicalBlockFields(editorConfig);
+    const blockTranslations =
+      blockConfig && lexicalFieldCrowdinArticleDirectoryId
+        ? await this.getBlockTranslations({
+            blockConfig,
+            file,
+            locale,
+            crowdinArticleDirectoryId: lexicalFieldCrowdinArticleDirectoryId,
+          })
+        : null;
+
+    return (
+      convertHtmlToLexical(data, blockTranslations) || {
+        root: {
+          type: 'root',
+          format: '',
+          indent: 0,
+          version: 1,
+          children: [
+            {
+              children: [
+                {
+                  detail: 0,
+                  format: 0,
+                  mode: 'normal',
+                  style: '',
+                  text: 'lexical configuration not found',
+                  type: 'text',
+                  version: 1,
+                },
+              ],
+              direction: 'ltr',
+              format: '',
+              indent: 0,
+              type: 'quote',
+              version: 1,
+            },
+          ],
+          direction: 'ltr',
+        },
+      }
+    );
   }
 
   private async buildTranslationFile({


### PR DESCRIPTION
## Item 3 — split `getTranslation()` into strategy methods

`translations.ts:getTranslation()` reduced from 154 lines to ~55. The dispatcher now resolves the file, fetches data from Crowdin, then calls one of:

- `getJsonTranslation(data)` — `JSON.parse`, returns object
- `getSlateTranslation(data)` — `convertHtmlToSlate` wrapper
- `getLexicalTranslation({ data, file, fieldName, locale, editorConfig })` — resolves the lexical article directory, fetches block translations, calls `convertHtmlToLexical` with the Lexical fallback root on empty result

All three are private. `getLexicalTranslation` takes `NonNullable<ReturnType<typeof getLexicalEditorConfig>>` so the caller's truthiness guard is enforced at the type level.