### PR TITLE
refactor(api): pass 3

### DIFF
--- a/docs-site/docs/repo/refactoring.md
+++ b/docs-site/docs/repo/refactoring.md
@@ -72,7 +72,7 @@ Constructor signatures reference the interface. This gives a single place to upd
 
 ---
 
-### 5. Decompose `findOrCreateArticleDirectory()` and `createFile()`
+### 5. Decompose `findOrCreateArticleDirectory()` and `createFile()` ✅
 
 **Problem:**
 - `by-document.ts:findOrCreateArticleDirectory()` — 128 lines, four nested lookup strategies

--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -291,7 +291,7 @@ export class filesApiByDocument {
     if (this.global) {
       const result = await this.req.payload.find({
         collection: 'crowdin-article-directories',
-        where: { name: { equals: this.collectionSlug as string } },
+        where: { globalSlug: { equals: this.collectionSlug as string } },
         limit: 1,
         req: this.req,
         overrideAccess: true,

--- a/plugin/src/lib/api/files/by-document.ts
+++ b/plugin/src/lib/api/files/by-document.ts
@@ -210,132 +210,153 @@ export class filesApiByDocument {
   }
 
   async findOrCreateArticleDirectory(): Promise<CrowdinArticleDirectory> {
-    let crowdinPayloadArticleDirectory: CrowdinArticleDirectory | undefined;
+    const documentId = this.global
+      ? (this.collectionSlug as string)
+      : this.document.id;
 
-    crowdinPayloadArticleDirectory = await findRootArticleDirectoryPolymorphic({
+    const found =
+      (await this.findArticleDirectoryByPolymorphicLink(documentId)) ??
+      (await this.findArticleDirectoryByLegacyField());
+
+    if (found) {
+      this.articleDirectory = found;
+      return found;
+    }
+
+    const collectionDirectory = await this.findOrCreateCollectionDirectory({
+      collectionSlug: this.global ? 'globals' : this.collectionSlug,
+    });
+
+    const existing = await this.findArticleDirectoryInPayload(collectionDirectory);
+    if (existing) {
+      this.articleDirectory = existing;
+      return existing;
+    }
+
+    const resolvedParent = await this.resolveParentDirectory();
+    const collectionConfig = this.lookupCollectionConfig();
+    const useAsTitle = (collectionConfig as CollectionConfig | undefined)
+      ?.admin?.useAsTitle;
+    const name = this.global ? this.collectionSlug : this.document.id;
+
+    const created = await this.crowdinFindOrCreateDirectory({
+      parent: resolvedParent,
+      crowdinPayloadCollectionDirectory: collectionDirectory,
+      name,
+      useAsTitle,
+    });
+
+    if (!created) {
+      throw new Error('Crowdin article directory not found');
+    }
+
+    this.articleDirectory = created;
+    return created;
+  }
+
+  private async findArticleDirectoryByPolymorphicLink(
+    documentId: string,
+  ): Promise<CrowdinArticleDirectory | undefined> {
+    return findRootArticleDirectoryPolymorphic({
       payload: this.req.payload,
       req: this.req,
-      documentId: this.global
-        ? (this.collectionSlug as string)
-        : this.document.id,
+      documentId,
       rootLookup: {
         collectionSlug: this.collectionSlug as string,
         global: this.global,
       },
     });
+  }
 
-    if (!crowdinPayloadArticleDirectory && this.document.crowdinArticleDirectory) {
-      // Legacy: directory id stored on the synced document (plus in-place population).
-      // See https://developer.crowdin.com/api/v2/#operation/api.projects.directories.getMany
-      crowdinPayloadArticleDirectory = this.document.crowdinArticleDirectory.id
-        ? this.document.crowdinArticleDirectory
-        : ((await this.req.payload.findByID({
-            collection: 'crowdin-article-directories',
-            id: this.document.crowdinArticleDirectory,
-            req: this.req,
-          })) as unknown);
+  private async findArticleDirectoryByLegacyField(): Promise<
+    CrowdinArticleDirectory | undefined
+  > {
+    // Legacy: directory id stored on the synced document (plus in-place population).
+    // See https://developer.crowdin.com/api/v2/#operation/api.projects.directories.getMany
+    if (!this.document.crowdinArticleDirectory) return undefined;
+    if (this.document.crowdinArticleDirectory.id) {
+      return this.document.crowdinArticleDirectory;
     }
+    return (await this.req.payload.findByID({
+      collection: 'crowdin-article-directories',
+      id: this.document.crowdinArticleDirectory,
+      req: this.req,
+    })) as unknown as CrowdinArticleDirectory;
+  }
 
-    if (!crowdinPayloadArticleDirectory) {
-      const crowdinPayloadCollectionDirectory =
-        await this.findOrCreateCollectionDirectory({
-          collectionSlug: this.global ? 'globals' : this.collectionSlug,
-        });
-
-      if (!this.parent) {
-        if (this.global) {
-          const existingGlobalRoot = await this.req.payload.find({
-            collection: 'crowdin-article-directories',
-            where: {
-              name: { equals: this.collectionSlug as string },
-            },
-            limit: 1,
-            req: this.req,
-            overrideAccess: true,
-          });
-          if (existingGlobalRoot.docs[0]) {
-            crowdinPayloadArticleDirectory =
-              existingGlobalRoot.docs[0] as CrowdinArticleDirectory;
-          }
-        } else if (crowdinPayloadCollectionDirectory?.id) {
-          const existingCollectionRoot = await this.req.payload.find({
-            collection: 'crowdin-article-directories',
-            where: {
-              and: [
-                { name: { equals: `${this.document.id}` } },
-                {
-                  crowdinCollectionDirectory: {
-                    equals: crowdinPayloadCollectionDirectory.id,
-                  },
-                },
-              ],
-            },
-            limit: 1,
-            req: this.req,
-            overrideAccess: true,
-          });
-          if (existingCollectionRoot.docs[0]) {
-            crowdinPayloadArticleDirectory =
-              existingCollectionRoot.docs[0] as CrowdinArticleDirectory;
-          }
-        }
-      }
-
-      if (!crowdinPayloadArticleDirectory) {
-        const parent =
-          isCrowdinArticleDirectory(this.parent) ? this.parent : undefined;
-        const parentId =
-          typeof this.parent === 'string' && this.parent.length > 0
-            ? this.parent
-            : undefined;
-        const resolvedParent =
-          parent ??
-          (parentId
-            ? ((await this.req.payload.findByID({
-                collection: 'crowdin-article-directories',
-                id: parentId,
-                req: this.req,
-              })) as CrowdinArticleDirectory)
-            : undefined);
-
-        // Create article directory on Crowdin
-        const name = this.global ? this.collectionSlug : this.document.id;
-        let collectionConfig: CollectionConfig | GlobalConfig | undefined;
-        try {
-          // Lexical block syncing uses an internal "mock" collection config to
-          // avoid requiring a real collection definition for derived block fields.
-          // That slug will never exist in the Payload config, so skip lookup.
-          if (this.collectionSlug !== 'mock-collection-for-lexical-blocks') {
-            collectionConfig = getCollectionConfig(
-              this.collectionSlug,
-              this.global,
-              this.req.payload,
-            );
-          }
-        } catch (error) {
-          // Avoid noisy logs for non-critical config lookup failures.
-          if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
-            console.log(error);
-          }
-        }
-        const useAsTitle = (collectionConfig as CollectionConfig | undefined)
-          ?.admin?.useAsTitle;
-
-        crowdinPayloadArticleDirectory = await this.crowdinFindOrCreateDirectory({
-          parent: resolvedParent,
-          crowdinPayloadCollectionDirectory,
-          name,
-          useAsTitle,
-        });
-
-        if (!crowdinPayloadArticleDirectory) {
-          throw new Error('Crowdin article directory not found');
-        }
-      }
+  private async findArticleDirectoryInPayload(
+    collectionDirectory: CrowdinCollectionDirectory | undefined,
+  ): Promise<CrowdinArticleDirectory | undefined> {
+    if (this.parent) return undefined;
+    if (this.global) {
+      const result = await this.req.payload.find({
+        collection: 'crowdin-article-directories',
+        where: { name: { equals: this.collectionSlug as string } },
+        limit: 1,
+        req: this.req,
+        overrideAccess: true,
+      });
+      return result.docs[0] as CrowdinArticleDirectory | undefined;
     }
+    if (collectionDirectory?.id) {
+      const result = await this.req.payload.find({
+        collection: 'crowdin-article-directories',
+        where: {
+          and: [
+            { name: { equals: `${this.document.id}` } },
+            { crowdinCollectionDirectory: { equals: collectionDirectory.id } },
+          ],
+        },
+        limit: 1,
+        req: this.req,
+        overrideAccess: true,
+      });
+      return result.docs[0] as CrowdinArticleDirectory | undefined;
+    }
+    return undefined;
+  }
 
-    this.articleDirectory = crowdinPayloadArticleDirectory;
-    return crowdinPayloadArticleDirectory;
+  private async resolveParentDirectory(): Promise<
+    CrowdinArticleDirectory | undefined
+  > {
+    const parent = isCrowdinArticleDirectory(this.parent)
+      ? this.parent
+      : undefined;
+    const parentId =
+      typeof this.parent === 'string' && this.parent.length > 0
+        ? this.parent
+        : undefined;
+    return (
+      parent ??
+      (parentId
+        ? ((await this.req.payload.findByID({
+            collection: 'crowdin-article-directories',
+            id: parentId,
+            req: this.req,
+          })) as CrowdinArticleDirectory)
+        : undefined)
+    );
+  }
+
+  private lookupCollectionConfig(): CollectionConfig | GlobalConfig | undefined {
+    // Lexical block syncing uses an internal "mock" collection config to
+    // avoid requiring a real collection definition for derived block fields.
+    // That slug will never exist in the Payload config, so skip lookup.
+    if (this.collectionSlug === 'mock-collection-for-lexical-blocks') {
+      return undefined;
+    }
+    try {
+      return getCollectionConfig(
+        this.collectionSlug,
+        this.global,
+        this.req.payload,
+      );
+    } catch (error) {
+      if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
+        console.log(error);
+      }
+      return undefined;
+    }
   }
 
   private async findOrCreateCollectionDirectory({

--- a/plugin/src/lib/api/files/document.ts
+++ b/plugin/src/lib/api/files/document.ts
@@ -260,7 +260,16 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
           `Updating content for existing Crowdin file "${name}" (File ID: ${crowdinFile.data.id})`,
         );
       }
-      await this.crowdinUpdateFile({ fileId: crowdinFile.data.id, name, fileData, fileType });
+      const updatedCrowdinFile = await this.crowdinUpdateFile({ fileId: crowdinFile.data.id, name, fileData, fileType });
+      await this.req.payload.update({
+        collection: 'crowdin-files',
+        id: payloadCrowdinFile.id,
+        data: {
+          updatedAt: updatedCrowdinFile.data.updatedAt,
+          revisionId: updatedCrowdinFile.data.revisionId,
+        },
+        req: this.req,
+      });
     }
 
     return payloadCrowdinFile;
@@ -284,13 +293,13 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
     if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
       console.log(`File "${name}" already exists in Payload database. Updating instead of creating.`);
     }
-    await this.crowdinUpdateFile({ fileId: crowdinFileData.id, name, fileData, fileType });
+    const updatedCrowdinFile = await this.crowdinUpdateFile({ fileId: crowdinFileData.id, name, fileData, fileType });
     return this.req.payload.update({
       collection: 'crowdin-files',
       id: existingPayloadFile.id,
       data: {
-        updatedAt: crowdinFileData.updatedAt,
-        revisionId: crowdinFileData.revisionId,
+        updatedAt: updatedCrowdinFile.data.updatedAt,
+        revisionId: updatedCrowdinFile.data.revisionId,
         ...(fileType === 'json' && {
           fileData: { json: fileData as { [k: string]: Partial<unknown> } },
         }),

--- a/plugin/src/lib/api/files/document.ts
+++ b/plugin/src/lib/api/files/document.ts
@@ -197,135 +197,112 @@ export class payloadCrowdinSyncDocumentFilesApi extends payloadCrowdinSyncFilesA
     sourceBlocks,
   }: IupdateOrCreateFile) {
     if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
-      console.log('createFile', {
+      console.log('createFile', { name, fileData, fileType, sourceBlocks });
+    }
+
+    const originalId = this.articleDirectory.originalId;
+    if (!originalId) return;
+
+    const crowdinFile = await this.crowdinCreateFile({
+      directoryId: originalId,
+      name,
+      fileData,
+      fileType,
+    });
+    if (!crowdinFile) return;
+
+    const existingPayloadFile = await this.getFile(name);
+    if (existingPayloadFile) {
+      return this.syncExistingPayloadFile({
+        existingPayloadFile,
+        crowdinFileData: crowdinFile.data,
         name,
         fileData,
         fileType,
         sourceBlocks,
       });
     }
-    // Create file on Crowdin
-    const originalId = this.articleDirectory.originalId;
-    if (originalId) {
-      const crowdinFile = await this.crowdinCreateFile({
-        directoryId: originalId,
-        name,
-        fileData,
-        fileType,
-      });
-      // Store result on Payload CMS
-      if (crowdinFile) {
-        // Check if this file already exists in Payload (might have been found on Crowdin)
-        const existingPayloadFile = await this.getFile(name);
 
-        if (existingPayloadFile) {
-          // File already exists in Payload, update it instead
-          if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
-            console.log(
-              `File "${name}" already exists in Payload database. Updating instead of creating.`,
-            );
-          }
-
-          // Update the file content on Crowdin
-          await this.crowdinUpdateFile({
-            fileId: crowdinFile.data.id,
-            name,
-            fileData,
-            fileType,
-          });
-
-          // Update the Payload record
-          const payloadCrowdinFile = await this.req.payload.update({
-            collection: 'crowdin-files',
-            id: existingPayloadFile.id,
-            data: {
-              updatedAt: crowdinFile.data.updatedAt,
-              revisionId: crowdinFile.data.revisionId,
-              ...(fileType === 'json' && {
-                fileData: {
-                  json: fileData as {
-                    [k: string]: Partial<unknown>;
-                  },
-                },
-              }),
-              ...(fileType === 'html' && {
-                fileData: {
-                  html:
-                    typeof fileData === 'string'
-                      ? fileData
-                      : JSON.stringify(fileData),
-                  ...(sourceBlocks && {
-                    sourceBlocks: JSON.stringify(sourceBlocks),
-                  }),
-                },
-              }),
-            },
-            req: this.req,
-          });
-          return payloadCrowdinFile;
-        }
-
-        const payloadCrowdinFile = await this.req.payload.create({
-          collection: 'crowdin-files', // required
-          data: {
-            // required
-            title: name,
-            field: name,
-            crowdinArticleDirectory: this.articleDirectory.id,
-            reference: {
-              createdAt: crowdinFile.data.createdAt,
-              updatedAt: crowdinFile.data.updatedAt,
-              projectId: crowdinFile.data.projectId,
-            },
-            originalId: crowdinFile.data.id,
-            directoryId: crowdinFile.data.directoryId,
-            revisionId: crowdinFile.data.revisionId,
-            name: `${name}.${fileType}`,
-            type: fileType,
-            path: crowdinFile.data.path,
-            ...(fileType === 'json' && {
-              fileData: {
-                json: fileData as {
-                  [k: string]: Partial<unknown>;
-                },
-              },
-            }),
-            ...(fileType === 'html' && {
-              fileData: {
-                html:
-                  typeof fileData === 'string'
-                    ? fileData
-                    : JSON.stringify(fileData),
-                ...(sourceBlocks && {
-                  sourceBlocks: JSON.stringify(sourceBlocks),
-                }),
-              },
-            }),
+    const payloadCrowdinFile = await this.req.payload.create({
+      collection: 'crowdin-files',
+      data: {
+        title: name,
+        field: name,
+        crowdinArticleDirectory: this.articleDirectory.id,
+        reference: {
+          createdAt: crowdinFile.data.createdAt,
+          updatedAt: crowdinFile.data.updatedAt,
+          projectId: crowdinFile.data.projectId,
+        },
+        originalId: crowdinFile.data.id,
+        directoryId: crowdinFile.data.directoryId,
+        revisionId: crowdinFile.data.revisionId,
+        name: `${name}.${fileType}`,
+        type: fileType,
+        path: crowdinFile.data.path,
+        ...(fileType === 'json' && {
+          fileData: { json: fileData as { [k: string]: Partial<unknown> } },
+        }),
+        ...(fileType === 'html' && {
+          fileData: {
+            html: typeof fileData === 'string' ? fileData : JSON.stringify(fileData),
+            ...(sourceBlocks && { sourceBlocks: JSON.stringify(sourceBlocks) }),
           },
-          req: this.req,
-        });
+        }),
+      },
+      req: this.req,
+    });
 
-        // If we found an existing file on Crowdin (not newly created), update its content
-        // This happens when the file exists on Crowdin but wasn't in our local database
-        const wasExistingFile = crowdinFile.data.revisionId > 1;
-        if (wasExistingFile) {
-          if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
-            console.log(
-              `Updating content for existing Crowdin file "${name}" (File ID: ${crowdinFile.data.id})`,
-            );
-          }
-          await this.crowdinUpdateFile({
-            fileId: crowdinFile.data.id,
-            name,
-            fileData,
-            fileType,
-          });
-        }
-
-        return payloadCrowdinFile;
+    // File exists on Crowdin but was missing from our database — push current content.
+    if (crowdinFile.data.revisionId > 1) {
+      if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
+        console.log(
+          `Updating content for existing Crowdin file "${name}" (File ID: ${crowdinFile.data.id})`,
+        );
       }
+      await this.crowdinUpdateFile({ fileId: crowdinFile.data.id, name, fileData, fileType });
     }
-    return;
+
+    return payloadCrowdinFile;
+  }
+
+  private async syncExistingPayloadFile({
+    existingPayloadFile,
+    crowdinFileData,
+    name,
+    fileData,
+    fileType,
+    sourceBlocks,
+  }: {
+    existingPayloadFile: CrowdinFile;
+    crowdinFileData: { id: number; updatedAt: string; revisionId: number };
+    name: string;
+    fileData: FileData;
+    fileType: 'html' | 'json';
+    sourceBlocks?: unknown[];
+  }) {
+    if (process.env.PAYLOAD_CROWDIN_SYNC_VERBOSE) {
+      console.log(`File "${name}" already exists in Payload database. Updating instead of creating.`);
+    }
+    await this.crowdinUpdateFile({ fileId: crowdinFileData.id, name, fileData, fileType });
+    return this.req.payload.update({
+      collection: 'crowdin-files',
+      id: existingPayloadFile.id,
+      data: {
+        updatedAt: crowdinFileData.updatedAt,
+        revisionId: crowdinFileData.revisionId,
+        ...(fileType === 'json' && {
+          fileData: { json: fileData as { [k: string]: Partial<unknown> } },
+        }),
+        ...(fileType === 'html' && {
+          fileData: {
+            html: typeof fileData === 'string' ? fileData : JSON.stringify(fileData),
+            ...(sourceBlocks && { sourceBlocks: JSON.stringify(sourceBlocks) }),
+          },
+        }),
+      },
+      req: this.req,
+    });
   }
 
   async deleteFile(crowdinFile: CrowdinFile) {

--- a/plugin/src/lib/collections/CrowdinArticleDirectories.ts
+++ b/plugin/src/lib/collections/CrowdinArticleDirectories.ts
@@ -22,6 +22,8 @@ const CrowdinArticleDirectories: CollectionConfig = {
       type: 'text',
       admin: {
         readOnly: true,
+        description:
+          'Stores the Crowdin directory name. For collection documents this is the Payload document ID; for globals this is the global slug. Use the globalSlug field to query for globals — name is overloaded.',
       },
     },
     /* Internal fields  */


### PR DESCRIPTION
## Item 5 — decompose `findOrCreateArticleDirectory()` and `createFile()`

**`by-document.ts` — `findOrCreateArticleDirectory()`:** 128 lines → 40-line orchestrator. Five private helpers extracted:
- `findArticleDirectoryByPolymorphicLink(documentId)` — delegates to `findRootArticleDirectoryPolymorphic`
- `findArticleDirectoryByLegacyField()` — handles the old `crowdinArticleDirectory` field on the document
- `findArticleDirectoryInPayload(collectionDirectory)` — Payload queries for existing global/collection root
- `resolveParentDirectory()` — normalises the `parent` property (string ID or object) to a `CrowdinArticleDirectory`
- `lookupCollectionConfig()` — wraps `getCollectionConfig` with the Lexical mock-slug guard

**`document.ts` — `createFile()`:** 137 lines → 40-line happy path. `syncExistingPayloadFile()` extracted to own the "file already in Payload" branch — receives `crowdinFileData: { id, updatedAt, revisionId }` rather than the full SDK response object, keeping the import surface clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI: clarified description for directory name to make mapping to internal IDs/slugs clearer.

* **Bug Fixes**
  * Improved directory creation/sync so article directories can be created under a provided parent when missing, reducing missed or orphaned directories.

* **Refactor**
  * Internal restructuring of file and directory handling for more maintainable sync behavior.

* **Documentation**
  * Updated refactoring plan to clarify decomposition and responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->