### PR TITLE
ci(github): conventional commits and labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,38 @@
+# Auto-label PRs based on changed file paths.
+# Used by .github/workflows/pr-labels.yml (actions/labeler).
+
+"area: plugin":
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugin/src/lib/**
+
+"area: test-installation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - dev/**
+          - dev-alternative-config/**
+
+"area: tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.spec.ts"
+          - "**/*.test.ts"
+          - "**/*.spec.tsx"
+          - "**/*.test.tsx"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs-site/**
+          - "**/*.md"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+"area: deps":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/package.json"
+          - "**/package-lock.json"

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,77 @@
+name: PR labels
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply area labels (path-based)
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+
+      - name: Apply type labels (PR title / conventional commits)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const title = context.payload.pull_request.title || '';
+
+            // Type label definitions — created on first use if absent.
+            const typeLabelDefs = [
+              { name: 'type: feature',  color: '0075ca', description: 'New feature or request' },
+              { name: 'type: fix',      color: 'd73a4a', description: 'Bug fix' },
+              { name: 'type: docs',     color: '0052cc', description: 'Documentation only' },
+              { name: 'type: test',     color: 'bfd4f2', description: 'Test additions or changes' },
+              { name: 'type: refactor', color: 'e4e669', description: 'Code refactoring without behaviour change' },
+              { name: 'type: perf',     color: 'f9d0c4', description: 'Performance improvement' },
+              { name: 'type: deps',     color: 'c5def5', description: 'Dependency update' },
+              { name: 'type: chore',    color: 'ffffff', description: 'Maintenance and housekeeping' },
+              { name: 'type: build',    color: 'fef2c0', description: 'Build system or tooling' },
+              { name: 'type: ci',       color: 'e99695', description: 'CI/CD changes' },
+            ];
+
+            const rules = [
+              { re: /^feat(\(.+\))?:/i,               label: 'type: feature' },
+              { re: /^fix(\(.+\))?:/i,                label: 'type: fix' },
+              { re: /^docs(\(.+\))?:/i,               label: 'type: docs' },
+              { re: /^test(\(.+\))?:/i,               label: 'type: test' },
+              { re: /^refactor(\(.+\))?:/i,           label: 'type: refactor' },
+              { re: /^perf(\(.+\))?:/i,               label: 'type: perf' },
+              { re: /^chore\(\s*deps(-dev)?\s*\):/i,  label: 'type: deps' },
+              { re: /^chore(\(.+\))?:/i,              label: 'type: chore' },
+              { re: /^build(\(.+\))?:/i,              label: 'type: build' },
+              { re: /^ci(\(.+\))?:/i,                 label: 'type: ci' },
+            ];
+
+            const matched = rules.filter(r => r.re.test(title)).map(r => r.label);
+            if (matched.length === 0) {
+              core.info(`No type label matched PR title: "${title}"`);
+              return;
+            }
+
+            // Ensure matched labels exist before applying them.
+            for (const label of matched) {
+              const def = typeLabelDefs.find(d => d.name === label);
+              if (!def) continue;
+              try {
+                await github.rest.issues.createLabel({ owner, repo, ...def });
+              } catch (e) {
+                if (e.status !== 422) throw e; // 422 = already exists
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [...new Set(matched)],
+            });

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply area labels (path-based)
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
 
       - name: Apply type labels (PR title / conventional commits)
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,7 +4,7 @@ name: PR title
 # This matters because PRs are squash-merged, making the title the commit message on main.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,50 @@
+name: PR title
+
+# Enforces Conventional Commits format on PR titles.
+# This matters because PRs are squash-merged, making the title the commit message on main.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            test
+            refactor
+            perf
+            chore
+            build
+            ci
+          # Scopes are optional but if present must match a known area.
+          # Keep in sync with labeler.yml area labels.
+          scopes: |
+            plugin
+            test-installation
+            tests
+            docs
+            ci
+            deps
+            bydocument
+            translations
+            helpers
+            migrations
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the expected pattern. Please ensure your PR title
+            follows the Conventional Commits spec:
+            https://www.conventionalcommits.org

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,19 +28,6 @@ jobs:
             chore
             build
             ci
-          # Scopes are optional but if present must match a known area.
-          # Keep in sync with labeler.yml area labels.
-          scopes: |
-            plugin
-            test-installation
-            tests
-            docs
-            ci
-            deps
-            bydocument
-            translations
-            helpers
-            migrations
           requireScope: false
           subjectPattern: ^.+$
           subjectPatternError: |

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/docs-site/docs/repo/pr-labels.md
+++ b/docs-site/docs/repo/pr-labels.md
@@ -40,4 +40,4 @@ Applied by the `actions/github-script` step in `.github/workflows/pr-labels.yml`
 
 Allowed types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`, `build`, `ci`.
 
-Scopes are optional. When provided they should match a known area (`plugin`, `test-installation`, `tests`, `docs`, `ci`, `deps`) or a code-level scope used in the commit history (`bydocument`, `translations`, `helpers`, `migrations`).
+Scopes are optional and free-form — use anything that helps identify what changed (a filename, function name, area, etc.). Examples: `ci(github):`, `fix(bydocument):`, `refactor(translations):`.

--- a/docs-site/docs/repo/pr-labels.md
+++ b/docs-site/docs/repo/pr-labels.md
@@ -1,0 +1,43 @@
+# PR labels
+
+Automated labelling is configured across two files.
+
+## Area labels (path-based)
+
+Defined in `.github/labeler.yml` and applied by `actions/labeler@v5`. Labels are created automatically on first use.
+
+| Label | Paths |
+|-------|-------|
+| `area: plugin` | `plugin/src/lib/**` |
+| `area: test-installation` | `dev/**`, `dev-alternative-config/**` |
+| `area: tests` | `**/*.spec.ts`, `**/*.test.ts` |
+| `area: docs` | `docs-site/**`, `**/*.md` |
+| `area: ci` | `.github/**` |
+| `area: deps` | `**/package.json`, `**/package-lock.json` |
+
+Labels stack — a plugin unit test change receives both `area: plugin` and `area: tests`.
+
+## Type labels (PR title)
+
+Applied by the `actions/github-script` step in `.github/workflows/pr-labels.yml` based on the Conventional Commits prefix in the PR title. Labels are created on first use.
+
+| Label | Prefix |
+|-------|--------|
+| `type: feature` | `feat:` |
+| `type: fix` | `fix:` |
+| `type: docs` | `docs:` |
+| `type: test` | `test:` |
+| `type: refactor` | `refactor:` |
+| `type: perf` | `perf:` |
+| `type: deps` | `chore(deps):` |
+| `type: chore` | `chore:` |
+| `type: build` | `build:` |
+| `type: ci` | `ci:` |
+
+## Conventional Commits enforcement
+
+`.github/workflows/pr-title.yml` uses `amannn/action-semantic-pull-request@v5` to fail CI if the PR title does not conform to the Conventional Commits spec. This matters because PRs are squash-merged, making the title the resulting commit message on `main`.
+
+Allowed types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`, `build`, `ci`.
+
+Scopes are optional. When provided they should match a known area (`plugin`, `test-installation`, `tests`, `docs`, `ci`, `deps`) or a code-level scope used in the commit history (`bydocument`, `translations`, `helpers`, `migrations`).

--- a/docs-site/docs/repo/pr-labels.md
+++ b/docs-site/docs/repo/pr-labels.md
@@ -29,7 +29,7 @@ Applied by the `actions/github-script` step in `.github/workflows/pr-labels.yml`
 | `type: test` | `test:` |
 | `type: refactor` | `refactor:` |
 | `type: perf` | `perf:` |
-| `type: deps` | `chore(deps):` |
+| `type: deps` | `chore(deps):`, `chore(deps-dev):` |
 | `type: chore` | `chore:` |
 | `type: build` | `build:` |
 | `type: ci` | `ci:` |

--- a/docs-site/docs/repo/pr-labels.md
+++ b/docs-site/docs/repo/pr-labels.md
@@ -10,7 +10,7 @@ Defined in `.github/labeler.yml` and applied by `actions/labeler@v5`. Labels are
 |-------|-------|
 | `area: plugin` | `plugin/src/lib/**` |
 | `area: test-installation` | `dev/**`, `dev-alternative-config/**` |
-| `area: tests` | `**/*.spec.ts`, `**/*.test.ts` |
+| `area: tests` | `**/*.spec.ts`, `**/*.test.ts`, `**/*.spec.tsx`, `**/*.test.tsx` |
 | `area: docs` | `docs-site/**`, `**/*.md` |
 | `area: ci` | `.github/**` |
 | `area: deps` | `**/package.json`, `**/package-lock.json` |


### PR DESCRIPTION
Enforce conventional commits and create an automated pr labeler. Docs included in `docs-site/docs/repo/pr-labels.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI**
  * Automated PR labeling system that categorizes pull requests based on changed file paths and Conventional Commits-style prefixes in titles.
  * PR title validation workflow ensuring all PRs follow Conventional Commits format standards.

* **Documentation**
  * New documentation explaining the automated PR labeling and title validation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->