### PR TITLE
fix(plugin): collections: undefined causes QueryError on page load (#342)

### DIFF
--- a/dev/src/tests/collections/issue-342.test.ts
+++ b/dev/src/tests/collections/issue-342.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration test for issue #342.
+ *
+ * When pluginOptions.collections is undefined the plugin treats all collections
+ * as active, but previously syncedCollectionSlugs returned [] which meant the
+ * collectionDocument field was never registered on crowdin-article-directories.
+ * The afterRead hook on crowdinArticleDirectory always queries
+ * `collectionDocument.value`, so any payload.findByID() call on a synced
+ * collection threw:
+ *
+ *   QueryError: The following paths cannot be queried:
+ *     collectionDocument, collectionDocument
+ *
+ * These tests verify that loading a collection document succeeds when
+ * pluginOptions.collections is not specified.
+ */
+import type { Payload } from 'payload'
+import { buildConfig, getPayload } from 'payload'
+import { crowdinSync, mockCrowdinClient } from 'payload-crowdin-sync'
+import nock from 'nock'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { slateEditor } from '@payloadcms/richtext-slate'
+import sharp from 'sharp'
+
+import { databaseAdapter } from '../databaseAdapter.js'
+import { runInit } from '../runInit'
+import { assertCrowdinNocksDone, cleanCrowdinNocks } from '../helpers/crowdin-nock'
+import Categories from '../../collections/Categories'
+import LocalizedPosts from '../../collections/LocalizedPosts'
+import Tags from '../../collections/Tags'
+import Users from '../../collections/Users'
+import Nav from '../../globals/Nav'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+// Plugin options with collections intentionally omitted — the issue #342 scenario.
+const pluginOptions = {
+  projectId: 323731,
+  directoryId: 1169,
+  token: 'fake-token',
+  localeMap: {
+    de_DE: { crowdinId: 'de' },
+    fr_FR: { crowdinId: 'fr' },
+  },
+  sourceLocale: 'en',
+  deleteCrowdinFiles: true,
+  // collections: undefined  ← deliberate omission — this is what triggered the bug
+}
+
+const mockClient = mockCrowdinClient(pluginOptions)
+
+const config = buildConfig({
+  admin: {
+    user: Users.slug,
+    importMap: { baseDir: path.resolve(dirname) },
+  },
+  plugins: [crowdinSync(pluginOptions)],
+  collections: [Categories, LocalizedPosts, Tags, Users],
+  globals: [Nav],
+  localization: {
+    locales: ['en', 'de_DE', 'fr_FR'],
+    defaultLocale: 'en',
+    fallback: true,
+  },
+  editor: slateEditor({}),
+  secret: 'TEST_SECRET',
+  db: databaseAdapter,
+  sharp,
+})
+
+let payload: Payload
+
+describe('issue #342 — collections: undefined does not cause QueryError', () => {
+  beforeAll(async () => {
+    await runInit('issue-342', false, true)
+    payload = await getPayload({ config: await config })
+  })
+
+  beforeEach(() => {
+    cleanCrowdinNocks()
+  })
+
+  afterEach(() => {
+    assertCrowdinNocksDone()
+  })
+
+  afterAll(async () => {
+    if (typeof payload.db.destroy === 'function') {
+      await payload.db.destroy()
+    }
+  })
+
+  it('reads a localized collection document without throwing a QueryError', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .twice()
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .reply(200, mockClient.addStorage())
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .reply(200, mockClient.createFile({}))
+
+    const created = await payload.create({
+      collection: 'localized-posts',
+      data: { title: 'Issue 342 test' },
+    })
+
+    // findByID triggers the afterRead hook which queries collectionDocument.value
+    // on crowdin-article-directories. Before the fix this threw a QueryError.
+    await expect(
+      payload.findByID({ collection: 'localized-posts', id: created.id }),
+    ).resolves.toBeDefined()
+  })
+
+  it('populates crowdinArticleDirectory on a localized collection document', async () => {
+    nock('https://api.crowdin.com')
+      .post(`/api/v2/projects/${pluginOptions.projectId}/directories`)
+      .once()
+      .reply(200, mockClient.createDirectory({}))
+      .post(`/api/v2/storages`)
+      .reply(200, mockClient.addStorage())
+      .post(`/api/v2/projects/${pluginOptions.projectId}/files`)
+      .reply(200, mockClient.createFile({}))
+
+    const created = await payload.create({
+      collection: 'localized-posts',
+      data: { title: 'Issue 342 population test' },
+    })
+
+    const result = await payload.findByID({
+      collection: 'localized-posts',
+      id: created.id,
+    })
+
+    expect((result as any).crowdinArticleDirectory).toBeDefined()
+    expect(typeof (result as any).crowdinArticleDirectory).toBe('object')
+  })
+
+  it('collectionDocument field is registered on crowdin-article-directories', async () => {
+    const articleDirCollection = payload.config.collections.find(
+      (c) => c.slug === 'crowdin-article-directories',
+    )
+    const tabsField = articleDirCollection?.fields?.[0] as any
+    const documentTab = tabsField?.tabs?.find((t: any) => t.label === 'Document')
+    const collectionDocumentField = documentTab?.fields?.find(
+      (f: any) => f.name === 'collectionDocument',
+    )
+
+    expect(
+      collectionDocumentField,
+      'collectionDocument must be registered when pluginOptions.collections is undefined',
+    ).toBeDefined()
+    expect(collectionDocumentField.type).toBe('relationship')
+    expect(collectionDocumentField.relationTo).toContain('localized-posts')
+  })
+})

--- a/plugin/src/lib/plugin.spec.ts
+++ b/plugin/src/lib/plugin.spec.ts
@@ -2,20 +2,19 @@ import { describe, expect, it } from 'vitest'
 import type { Config } from 'payload'
 import { crowdinSync } from './plugin'
 
-/**
- * Minimal Payload config with one collection that has a localized field.
- * Cast to avoid providing every required Config property — the plugin only
- * accesses collections, globals, jobs, and admin.
- */
-const minimalConfig = {
-  collections: [
-    {
-      slug: 'posts',
-      fields: [{ name: 'title', type: 'text', localized: true }],
-    },
-  ],
-  globals: [],
-} as unknown as Config
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const minimalCollection = {
+  slug: 'posts',
+  fields: [{ name: 'title', type: 'text', localized: true }],
+}
+
+const minimalGlobal = {
+  slug: 'nav',
+  fields: [{ name: 'label', type: 'text', localized: true }],
+}
 
 const basePluginOptions = {
   projectId: 123,
@@ -24,46 +23,229 @@ const basePluginOptions = {
   sourceLocale: 'en',
 }
 
-/**
- * Finds the `collectionDocument` field inside the crowdin-article-directories
- * collection added by the plugin. It lives inside the 'Document' tab of the
- * top-level tabs field.
- */
-function findCollectionDocumentField(outputConfig: Config) {
-  const articleDirCollection = outputConfig.collections?.find(
-    (c) => c.slug === 'crowdin-article-directories',
-  )
-  const tabsField = articleDirCollection?.fields?.[0] as any
-  const documentTab = tabsField?.tabs?.find((t: any) => t.label === 'Document')
-  return documentTab?.fields?.find((f: any) => f.name === 'collectionDocument')
+/** Build a minimal Config. The plugin only accesses collections, globals, jobs, and admin. */
+function buildConfig(overrides: { collections?: any[]; globals?: any[] } = {}): Config {
+  return {
+    collections: overrides.collections ?? [minimalCollection],
+    globals: overrides.globals ?? [],
+  } as unknown as Config
 }
 
-describe('crowdinSync — issue #342: collectionDocument field registration', () => {
-  it('registers collectionDocument in crowdin-article-directories when collections is not specified', () => {
-    // When pluginOptions.collections is undefined, collectionOrGlobalConfigActive()
-    // treats all collections as active and adds the afterRead hook that queries
-    // `collectionDocument.value`. But syncedCollectionSlugs currently returns []
-    // in this case, so collectionDocument is never added to the schema — causing
-    // Payload to throw a QueryError on every collection page load.
-    const outputConfig = crowdinSync(basePluginOptions)(minimalConfig)
+// ---------------------------------------------------------------------------
+// Helpers — navigate the crowdin-article-directories field structure
+// ---------------------------------------------------------------------------
 
-    const field = findCollectionDocumentField(outputConfig)
+function getArticleDirectoryCollection(outputConfig: Config) {
+  return outputConfig.collections?.find((c) => c.slug === 'crowdin-article-directories')
+}
 
-    expect(field, 'collectionDocument field must be registered when collections is not specified').toBeDefined()
+function getDocumentTab(outputConfig: Config) {
+  const collection = getArticleDirectoryCollection(outputConfig)
+  const tabsField = collection?.fields?.[0] as any
+  return tabsField?.tabs?.find((t: any) => t.label === 'Document') as any | undefined
+}
+
+function findCollectionDocumentField(outputConfig: Config) {
+  return getDocumentTab(outputConfig)?.fields?.find((f: any) => f.name === 'collectionDocument')
+}
+
+function findGlobalSlugField(outputConfig: Config) {
+  return getDocumentTab(outputConfig)?.fields?.find((f: any) => f.name === 'globalSlug')
+}
+
+// ---------------------------------------------------------------------------
+// collectionDocument field registration
+// ---------------------------------------------------------------------------
+
+describe('crowdinSync — collectionDocument field registration', () => {
+  it('registers the field when pluginOptions.collections is not specified (issue #342)', () => {
+    // Bug: syncedCollectionSlugs returned [] when collections was undefined,
+    // so collectionDocument was never added to the schema. The afterRead hook
+    // queries collectionDocument.value, causing a QueryError on every page load.
+    const output = crowdinSync(basePluginOptions)(buildConfig())
+
+    const field = findCollectionDocumentField(output)
+    expect(field, 'collectionDocument must be registered').toBeDefined()
     expect(field.type).toBe('relationship')
     expect(field.relationTo).toContain('posts')
   })
 
-  it('registers collectionDocument with explicit collections config (baseline)', () => {
-    const outputConfig = crowdinSync({
+  it('registers the field with an explicit collections config (baseline)', () => {
+    const output = crowdinSync({
       ...basePluginOptions,
       collections: ['posts'],
-    })(minimalConfig)
+    })(buildConfig())
 
-    const field = findCollectionDocumentField(outputConfig)
-
+    const field = findCollectionDocumentField(output)
     expect(field).toBeDefined()
     expect(field.type).toBe('relationship')
     expect(field.relationTo).toContain('posts')
+  })
+
+  it('does NOT register the field when config.collections is an empty array', () => {
+    const output = crowdinSync(basePluginOptions)(buildConfig({ collections: [] }))
+    expect(findCollectionDocumentField(output)).toBeUndefined()
+  })
+
+  it('does NOT register the field when config.collections is undefined', () => {
+    const output = crowdinSync(basePluginOptions)(
+      { globals: [] } as unknown as Config,
+    )
+    expect(findCollectionDocumentField(output)).toBeUndefined()
+  })
+
+  it('does NOT register the field when pluginOptions.collections is an empty array', () => {
+    const output = crowdinSync({
+      ...basePluginOptions,
+      collections: [],
+    })(buildConfig())
+    expect(findCollectionDocumentField(output)).toBeUndefined()
+  })
+
+  it('relationTo only contains the slugs listed in pluginOptions.collections', () => {
+    const configWithTwo = buildConfig({
+      collections: [
+        minimalCollection,
+        { slug: 'pages', fields: [{ name: 'body', type: 'text', localized: true }] },
+      ],
+    })
+    const output = crowdinSync({
+      ...basePluginOptions,
+      collections: ['posts'],
+    })(configWithTwo)
+
+    const field = findCollectionDocumentField(output)
+    expect(field).toBeDefined()
+    expect(field.relationTo).toContain('posts')
+    expect(field.relationTo).not.toContain('pages')
+  })
+
+  it('relationTo contains all collection slugs when pluginOptions.collections is undefined', () => {
+    const configWithTwo = buildConfig({
+      collections: [
+        minimalCollection,
+        { slug: 'pages', fields: [{ name: 'body', type: 'text', localized: true }] },
+      ],
+    })
+    const output = crowdinSync(basePluginOptions)(configWithTwo)
+
+    const field = findCollectionDocumentField(output)
+    expect(field).toBeDefined()
+    expect(field.relationTo).toContain('posts')
+    expect(field.relationTo).toContain('pages')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// globalSlug field registration
+// ---------------------------------------------------------------------------
+
+describe('crowdinSync — globalSlug field registration', () => {
+  it('registers the field when pluginOptions.globals is not specified and config has globals', () => {
+    const output = crowdinSync(basePluginOptions)(buildConfig({ globals: [minimalGlobal] }))
+
+    const field = findGlobalSlugField(output)
+    expect(field, 'globalSlug must be registered').toBeDefined()
+    expect(field.type).toBe('select')
+    expect(field.options).toContain('nav')
+  })
+
+  it('registers the field with an explicit globals config (baseline)', () => {
+    const output = crowdinSync({
+      ...basePluginOptions,
+      globals: ['nav'],
+    })(buildConfig({ globals: [minimalGlobal] }))
+
+    const field = findGlobalSlugField(output)
+    expect(field).toBeDefined()
+    expect(field.type).toBe('select')
+    expect(field.options).toContain('nav')
+  })
+
+  it('does NOT register the field when config.globals is an empty array', () => {
+    // Empty globals array in the config: no globals to sync, field must be absent.
+    const output = crowdinSync(basePluginOptions)(buildConfig({ globals: [] }))
+    expect(findGlobalSlugField(output)).toBeUndefined()
+  })
+
+  it('does NOT register the field when config.globals is undefined', () => {
+    const output = crowdinSync(basePluginOptions)(
+      { collections: [minimalCollection] } as unknown as Config,
+    )
+    expect(findGlobalSlugField(output)).toBeUndefined()
+  })
+
+  it('does NOT register the field when pluginOptions.globals is an empty array', () => {
+    const output = crowdinSync({
+      ...basePluginOptions,
+      globals: [],
+    })(buildConfig({ globals: [minimalGlobal] }))
+    expect(findGlobalSlugField(output)).toBeUndefined()
+  })
+
+  it('options only contains the slugs listed in pluginOptions.globals', () => {
+    const configWithTwo = buildConfig({
+      globals: [
+        minimalGlobal,
+        { slug: 'footer', fields: [{ name: 'text', type: 'text', localized: true }] },
+      ],
+    })
+    const output = crowdinSync({
+      ...basePluginOptions,
+      globals: ['nav'],
+    })(configWithTwo)
+
+    const field = findGlobalSlugField(output)
+    expect(field).toBeDefined()
+    expect(field.options).toContain('nav')
+    expect(field.options).not.toContain('footer')
+  })
+
+  it('options contains all global slugs when pluginOptions.globals is undefined', () => {
+    const configWithTwo = buildConfig({
+      globals: [
+        minimalGlobal,
+        { slug: 'footer', fields: [{ name: 'text', type: 'text', localized: true }] },
+      ],
+    })
+    const output = crowdinSync(basePluginOptions)(configWithTwo)
+
+    const field = findGlobalSlugField(output)
+    expect(field).toBeDefined()
+    expect(field.options).toContain('nav')
+    expect(field.options).toContain('footer')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Document tab presence
+// ---------------------------------------------------------------------------
+
+describe('crowdinSync — Document tab in crowdin-article-directories', () => {
+  it('omits the Document tab when no collections or globals are configured', () => {
+    const output = crowdinSync(basePluginOptions)(buildConfig({ collections: [], globals: [] }))
+    expect(getDocumentTab(output)).toBeUndefined()
+  })
+
+  it('includes the Document tab when only collections are present', () => {
+    const output = crowdinSync(basePluginOptions)(buildConfig({ globals: [] }))
+    expect(getDocumentTab(output)).toBeDefined()
+  })
+
+  it('includes the Document tab when only globals are present', () => {
+    const output = crowdinSync(basePluginOptions)(
+      buildConfig({ collections: [], globals: [minimalGlobal] }),
+    )
+    expect(getDocumentTab(output)).toBeDefined()
+  })
+
+  it('includes the Document tab with both fields when config has both collections and globals', () => {
+    const output = crowdinSync(basePluginOptions)(
+      buildConfig({ globals: [minimalGlobal] }),
+    )
+    const tab = getDocumentTab(output)
+    expect(tab).toBeDefined()
+    expect(tab.fields.map((f: any) => f.name)).toContain('collectionDocument')
+    expect(tab.fields.map((f: any) => f.name)).toContain('globalSlug')
   })
 })

--- a/plugin/src/lib/plugin.spec.ts
+++ b/plugin/src/lib/plugin.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { Config } from 'payload'
+import { crowdinSync } from './plugin'
+
+/**
+ * Minimal Payload config with one collection that has a localized field.
+ * Cast to avoid providing every required Config property — the plugin only
+ * accesses collections, globals, jobs, and admin.
+ */
+const minimalConfig = {
+  collections: [
+    {
+      slug: 'posts',
+      fields: [{ name: 'title', type: 'text', localized: true }],
+    },
+  ],
+  globals: [],
+} as unknown as Config
+
+const basePluginOptions = {
+  projectId: 123,
+  token: 'fake-token',
+  localeMap: { de: { crowdinId: 'de' } },
+  sourceLocale: 'en',
+}
+
+/**
+ * Finds the `collectionDocument` field inside the crowdin-article-directories
+ * collection added by the plugin. It lives inside the 'Document' tab of the
+ * top-level tabs field.
+ */
+function findCollectionDocumentField(outputConfig: Config) {
+  const articleDirCollection = outputConfig.collections?.find(
+    (c) => c.slug === 'crowdin-article-directories',
+  )
+  const tabsField = articleDirCollection?.fields?.[0] as any
+  const documentTab = tabsField?.tabs?.find((t: any) => t.label === 'Document')
+  return documentTab?.fields?.find((f: any) => f.name === 'collectionDocument')
+}
+
+describe('crowdinSync — issue #342: collectionDocument field registration', () => {
+  it('registers collectionDocument in crowdin-article-directories when collections is not specified', () => {
+    // When pluginOptions.collections is undefined, collectionOrGlobalConfigActive()
+    // treats all collections as active and adds the afterRead hook that queries
+    // `collectionDocument.value`. But syncedCollectionSlugs currently returns []
+    // in this case, so collectionDocument is never added to the schema — causing
+    // Payload to throw a QueryError on every collection page load.
+    const outputConfig = crowdinSync(basePluginOptions)(minimalConfig)
+
+    const field = findCollectionDocumentField(outputConfig)
+
+    expect(field, 'collectionDocument field must be registered when collections is not specified').toBeDefined()
+    expect(field.type).toBe('relationship')
+    expect(field.relationTo).toContain('posts')
+  })
+
+  it('registers collectionDocument with explicit collections config (baseline)', () => {
+    const outputConfig = crowdinSync({
+      ...basePluginOptions,
+      collections: ['posts'],
+    })(minimalConfig)
+
+    const field = findCollectionDocumentField(outputConfig)
+
+    expect(field).toBeDefined()
+    expect(field.type).toBe('relationship')
+    expect(field.relationTo).toContain('posts')
+  })
+})

--- a/plugin/src/lib/plugin.ts
+++ b/plugin/src/lib/plugin.ts
@@ -68,7 +68,7 @@ export const crowdinSync =
     const initFunctions: (() => void)[] = [];
 
     const syncedCollectionSlugs: string[] = (() => {
-      if (!pluginOptions.collections) return [];
+      if (!pluginOptions.collections) return (config.collections || []).map((c) => c.slug);
       const allowed = new Set(
         pluginOptions.collections.map((c) =>
           isCollectionOrGlobalConfigObject(c) ? c.slug : c,


### PR DESCRIPTION
## Summary

- Fixes a `QueryError: The following paths cannot be queried: collectionDocument` thrown on every collection page load when `pluginOptions.collections` is not specified
- Adds a comprehensive unit test suite covering all `collectionDocument` and `globalSlug` field registration scenarios
- Adds an integration test that verifies a collection document can be read without error under the affected config

## Root cause

When `pluginOptions.collections` is `undefined` the plugin is supposed to treat all collections as active — this is what `collectionOrGlobalConfigActive()` does. But `syncedCollectionSlugs` had an early return of `[]` in that case:

```ts
// before
if (!pluginOptions.collections) return [];
```

Because `syncedCollectionSlugs` was empty, the `collectionDocument` relationship field was never added to `crowdin-article-directories`. The `afterRead` hook added to every synced collection always queries `collectionDocument.value` on that collection, so any `findByID` or `find` call immediately threw a `QueryError` about the missing field.

The globals path already handled `undefined` correctly (returning all globals from the config). This fix makes collections consistent with that behaviour.

## Fix

```ts
// after
if (!pluginOptions.collections) return (config.collections || []).map((c) => c.slug);
```

## Tests

### Unit (`plugin/src/lib/plugin.spec.ts`)

18 tests across four `describe` blocks verifying schema field registration for all option/config combinations:

**`collectionDocument`**
- `pluginOptions.collections` undefined + collections in config → field registered *(the bug scenario)*
- Explicit `pluginOptions.collections` → field registered
- `config.collections = []` → field absent
- `config.collections` undefined → field absent
- `pluginOptions.collections = []` → field absent
- `relationTo` scoped to listed slugs when explicit
- `relationTo` includes all slugs when `collections` is undefined

**`globalSlug`**
- `pluginOptions.globals` undefined + globals in config → field registered
- Explicit `pluginOptions.globals` → field registered
- `config.globals = []` → field absent
- `config.globals` undefined → field absent
- `pluginOptions.globals = []` → field absent
- `options` scoped to listed slugs when explicit
- `options` includes all slugs when `globals` is undefined

**Document tab presence**
- No collections, no globals → tab absent
- Collections only → tab present
- Globals only → tab present
- Both → tab present with both fields

### Integration (`dev/src/tests/collections/issue-342.test.ts`)

Initialises a dedicated Payload instance with `pluginOptions.collections` omitted and runs three assertions:

1. `findByID` on a localized collection document resolves without throwing a `QueryError`
2. `crowdinArticleDirectory` is populated on the returned document (afterRead hook resolved successfully)
3. `collectionDocument` field is present in `payload.config` with the correct type and `relationTo`

## Closes

Closes #342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where undefined collections configuration caused errors during localized collection document synchronization, resolving QueryError when creating and retrieving documents.

## Tests
* Added test coverage validating Crowdin plugin schema field registration, relationship configuration, and Document tab presence based on configured collections and globals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->