### PR TITLE
fix(releaseplease): automate npm publish via trusted publishing (#59)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,33 +12,33 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      plugin_release_created: ${{ steps.release.outputs['plugin--release_created'] }}
+      plugin_version: ${{ steps.release.outputs['plugin--version'] }}
     steps:
       - uses: google-github-actions/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      # The logic below handles the npm publication:
-      - name: Checkout Repository
-        if: ${{ steps.release.outputs.releases_created }}
-        uses: actions/checkout@v2
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        if: ${{ steps.release.outputs.releases_created }}
-        with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
-      - name: Build Packages
-        if: ${{ steps.release.outputs.releases_created }}
-        run: |
-          npm install
-          nx build plugin
 
-      # Release Please has already incremented versions and published tags, so we just
-      # need to publish all unpublished versions to NPM here
-      # See: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package
-      - name: Publish to NPM
-        if: ${{ steps.release.outputs.releases_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: nx publish plugin
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.plugin_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm ci
+      - run: npx nx run plugin:build
+      - name: Publish to npm
+        working-directory: dist/plugin
+        run: npm publish --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       plugin_release_created: ${{ steps.release.outputs['plugin--release_created'] }}
       plugin_version: ${{ steps.release.outputs['plugin--version'] }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,8 +31,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org

--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ npm run test
 
 ### Release
 
-Build the plugin, change to the plugin directory and run `npm publish`.
+Releases are managed by [release-please](https://github.com/googleapis/release-please). When a release PR is merged to `main`, the [`release-please` workflow](.github/workflows/release-please.yml) builds and publishes `payload-crowdin-sync` to npm via [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers/).
+
+One-time npm setup (package maintainer): on [npmjs.com](https://www.npmjs.com/package/payload-crowdin-sync) → **Settings** → **Trusted publishing**, add a GitHub Actions publisher for repository `thompsonsj/payload-crowdin-sync` and workflow filename `release-please.yml`. After verifying automated publishes work, revoke the `NPM_TOKEN` repository secret.
+
+Manual publish remains available as a fallback:
 
 ```
 npm run release

--- a/docs-site/docs/repo/README.md
+++ b/docs-site/docs/repo/README.md
@@ -62,7 +62,11 @@ npm run test
 
 ### Release
 
-Build the plugin, change to the plugin directory and run `npm publish`.
+Releases are managed by [release-please](https://github.com/googleapis/release-please). When a release PR is merged to `main`, the [`release-please` workflow](https://github.com/thompsonsj/payload-crowdin-sync/blob/main/.github/workflows/release-please.yml) builds and publishes `payload-crowdin-sync` to npm via [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers/).
+
+One-time npm setup (package maintainer): on [npmjs.com](https://www.npmjs.com/package/payload-crowdin-sync) → **Settings** → **Trusted publishing**, add a GitHub Actions publisher for repository `thompsonsj/payload-crowdin-sync` and workflow filename `release-please.yml`. After verifying automated publishes work, revoke the `NPM_TOKEN` repository secret.
+
+Manual publish remains available as a fallback:
 
 ```
 npm run release


### PR DESCRIPTION
Closes #59 .

## Summary

- Fixes the `release-please` workflow so npm publish actually runs after a release PR is merged
- Moves publishing to a dedicated job using npm [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers/) instead of the long-lived `NPM_TOKEN` secret
- Updates release documentation in `README.md` and `docs-site/docs/repo/README.md`

## Root cause

The workflow had npm publish steps wired up since 2023, but they were always skipped. The release-please step was missing `id: release`, so every `if: ${{ steps.release.outputs.releases_created }}` condition evaluated to empty and the publish steps never ran. Confirmed on the 0.42.1 release (run 27142762866): `Checkout Repository`, `Setup Node`, `Build Packages`, and `Publish to NPM` all reported `skipped`, and the package was published manually two minutes later.

Additional problems in the old publish path:

- Gated on the global `releases_created` output rather than the `plugin` package specifically (this manifest tracks `.`, `plugin`, `dev`, and `dev-alternative-config`)
- Used `checkout@v2`, `setup-node@v1`, and Node 16 — incompatible with the current toolchain
- Ran `nx publish plugin`, which invokes `tools/scripts/publish.mjs` and hard-exits without a `--ver` argument (defaults dist-tag to `next`)

## Fix

**Workflow structure**

- Add `id: release` to the release-please step
- Expose `plugin--release_created` and `plugin--version` as job outputs
- Split publishing into a separate `publish` job, gated on `plugin_release_created == 'true'`

**Publish job**

- `actions/checkout@v5`, `actions/setup-node@v6`, Node 24.x
- `id-token: write` for OIDC; no `NODE_AUTH_TOKEN`
- Build with `npx nx run plugin:build`, publish from `dist/plugin` with `npm publish --access public` (matches the proven manual `npm run release` flow)

## Maintainer setup (required before first automated publish)

Configure a trusted publisher on [npmjs.com](https://www.npmjs.com/package/payload-crowdin-sync) → **Settings** → **Trusted publishing**:

| Field | Value |
|---|---|
| Organization or user | `thompsonsj` |
| Repository | `payload-crowdin-sync` |
| Workflow filename | `release-please.yml` |

The workflow filename must match exactly. After the first successful CI publish, revoke the `NPM_TOKEN` repository secret.

See also `tmp/npm-trusted-publisher-setup.md` for the full checklist.

## Test plan

- [ ] Merge this PR to `main`
- [x] Configure the npm trusted publisher (see above)
- [ ] Merge the next release-please version-bump PR
- [ ] Confirm the `release-please` workflow runs the `publish` job (not skipped)
- [ ] Confirm the new version appears on npm without running `npm run release` locally
- [x] Revoke `NPM_TOKEN` after verifying the automated publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use automated release management with secure npm publishing.

* **Documentation**
  * Added documentation for the automated release process, including one-time maintainer setup steps for secure publishing configuration. Manual publishing remains available as a fallback option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->