### PR TITLE
refactor(utilities): adopt Payload field primitives in getLocalizedFields (#65)

### DIFF
--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -1,9 +1,11 @@
 import type {
+  ArrayField,
   Block,
   CollapsibleField,
   CollectionConfig,
   Field,
   GlobalConfig,
+  GroupField,
   RowField
 } from 'payload';
 import {
@@ -25,10 +27,12 @@ const localizedFieldTypes = ['richText', 'text', 'textarea'];
 
 type IsLocalized = (field: Field, localizedParent?: boolean) => boolean;
 
-export const containsNestedFields = (field: Field) =>
+export const containsNestedFields = (field: Field): boolean =>
   fieldIsGroupType(field) || fieldIsArrayType(field) || fieldIsBlockType(field);
 
-const isCrowdinNestedDataField = (field: Field) =>
+const isCrowdinNestedDataField = (
+  field: Field,
+): field is GroupField | ArrayField =>
   fieldIsGroupType(field) || fieldIsArrayType(field);
 
 export const findField = ({

--- a/plugin/src/lib/utilities/index.ts
+++ b/plugin/src/lib/utilities/index.ts
@@ -6,6 +6,14 @@ import type {
   GlobalConfig,
   RowField
 } from 'payload';
+import {
+  fieldIsArrayType,
+  fieldIsBlockType,
+  fieldIsGroupType,
+  fieldIsID,
+  fieldShouldBeLocalized,
+  tabHasName,
+} from 'payload/shared';
 import deepEqual from 'deep-equal';
 import { FieldWithName, type CrowdinHtmlObject } from '../types';
 
@@ -15,12 +23,13 @@ import dot from 'dot-object';
 
 const localizedFieldTypes = ['richText', 'text', 'textarea'];
 
-const nestedFieldTypes = ['array', 'group', 'blocks'];
-
 type IsLocalized = (field: Field, localizedParent?: boolean) => boolean;
 
 export const containsNestedFields = (field: Field) =>
-  nestedFieldTypes.includes(field.type);
+  fieldIsGroupType(field) || fieldIsArrayType(field) || fieldIsBlockType(field);
+
+const isCrowdinNestedDataField = (field: Field) =>
+  fieldIsGroupType(field) || fieldIsArrayType(field);
 
 export const findField = ({
   dotNotation,
@@ -43,7 +52,7 @@ export const findField = ({
     return undefined;
   }
   for (const field of localizedFields) {
-    if (field.type === 'group' && keys.length > 1) {
+    if (fieldIsGroupType(field) && keys.length > 1) {
       const dotNotation = keys.slice(1).join(`.`);
       const search = findField({
         dotNotation,
@@ -54,7 +63,7 @@ export const findField = ({
         return search;
       }
     }
-    if (field.type === 'array' && keys.length > 2) {
+    if (fieldIsArrayType(field) && keys.length > 2) {
       const dotNotation = keys.slice(2).join(`.`);
       const search = findField({
         dotNotation,
@@ -65,7 +74,7 @@ export const findField = ({
         return search;
       }
     }
-    if (field.type === 'blocks' && keys.length > 3) {
+    if (fieldIsBlockType(field) && keys.length > 3) {
       const dotNotation = keys.slice(3).join(`.`);
       const blockType = keys[2];
       // find the block definition
@@ -119,7 +128,7 @@ export const getLocalizedFields = ({
     // exclude group, array and block fields with no localized fields
     // TODO: find a better way to do this - block, array and group logic is duplicated, and this filter needs to be compatible with field extraction logic later in this function
     .filter((field) => {
-      if (field.type === 'group' || field.type === 'array') {
+      if (isCrowdinNestedDataField(field)) {
         return containsLocalizedFields({
           fields: field.fields,
           type,
@@ -127,7 +136,7 @@ export const getLocalizedFields = ({
           isLocalized,
         });
       }
-      if (field.type === 'blocks') {
+      if (fieldIsBlockType(field)) {
         return field.blocks.find((block) =>
           containsLocalizedFields({
             fields: block.fields,
@@ -141,7 +150,7 @@ export const getLocalizedFields = ({
     })
     // recursion for group, array and blocks field
     .map((field) => {
-      if (field.type === 'group' || field.type === 'array') {
+      if (isCrowdinNestedDataField(field)) {
         return {
           ...field,
           fields: getLocalizedFields({
@@ -152,7 +161,7 @@ export const getLocalizedFields = ({
           }),
         };
       }
-      if (field.type === 'blocks') {
+      if (fieldIsBlockType(field)) {
         const blocks = field.blocks
           .map((block: Block) => {
             if (
@@ -294,7 +303,7 @@ export const convertTabs = ({
         const flattenedFields = field.tabs.reduce((tabFields, tab) => {
           return [
             ...tabFields,
-            'name' in tab
+            tabHasName(tab)
               ? ({
                   type: 'group',
                   name: tab.name,
@@ -342,8 +351,17 @@ export const getFieldSlugs = (fields: FieldWithName[]): string[] =>
     )
     .map((field: FieldWithName) => field.name);
 
-const hasLocalizedProp = (field: Field) =>
-  'localized' in field && field.localized;
+/**
+ * Crowdin treats children as syncable when a localized group/array/blocks parent
+ * sets localizedParent, even if the child lacks localized: true. Payload's
+ * fieldShouldBeLocalized uses the opposite rule for DB locale inheritance.
+ */
+const hasCrowdinLocalizationFlag = (
+  field: Field,
+  localizedParent = false,
+) =>
+  localizedParent ||
+  fieldShouldBeLocalized({ field, parentIsLocalized: localizedParent });
 
 /**
  * Is Localized Field
@@ -351,11 +369,11 @@ const hasLocalizedProp = (field: Field) =>
  * Note that `id` should be excluded - it is a `text` field that is added by Payload CMS.
  * Note that `blockName` should be excluded - it is a `text` field that is added by Payload CMS and is not localized.
  */
-export const isLocalizedField = (field: Field, addLocalizedProp = false) =>
-  (hasLocalizedProp(field) || addLocalizedProp) &&
+export const isLocalizedField = (field: Field, localizedParent = false) =>
+  hasCrowdinLocalizationFlag(field, localizedParent) &&
   (localizedFieldTypes.includes(field.type) || containsNestedFields(field)) &&
   !excludeBasedOnConfig(field) &&
-  (field as FieldWithName).name !== 'id' &&
+  !fieldIsID(field) &&
   (field as FieldWithName).name !== 'blockName';
 
 /**
@@ -367,7 +385,7 @@ export const isLocalizedField = (field: Field, addLocalizedProp = false) =>
 export const reLocalizeField = (field: Field) =>
   localizedFieldTypes.includes(field.type) &&
   !excludeBasedOnConfig(field) &&
-  (field as FieldWithName).name !== 'id';
+  !fieldIsID(field);
 
 const excludeBasedOnConfig = (field: Field) => {
   const description = `${get(field, 'admin.description', '')}`;


### PR DESCRIPTION
## Summary

- Phase 1 of the #65 investigation: adopt Payload's field type guards and localization helpers in `getLocalizedFields` and related utilities
- Replaces hand-rolled `field.type === '...'` checks and a local `nestedFieldTypes` array with `payload/shared` primitives
- Wraps Payload's `fieldShouldBeLocalized` to preserve Crowdin-specific parent-inheritance semantics
- No behaviour change intended — existing test suite is the safety net

Phase 2 (extracting helpers from the 119-line `getLocalizedFields` function) is deferred to a follow-up PR.

## Background

Issue #65 asked whether Payload provides functions that can replace `getLocalizedFields`. Investigation concluded there is no drop-in replacement — the plugin still needs Crowdin-specific json/html routing, opt-outs, and a pruned nested tree output. Payload's `payload/shared` exports do provide reliable field type guards and parent-aware localization checks that reduce bespoke recursion.

Tracked in `docs-site/docs/repo/refactoring-broad.md` §6.

## Changes

### Imports from `payload/shared`

| Primitive | Replaces |
|---|---|
| `fieldIsGroupType`, `fieldIsArrayType`, `fieldIsBlockType` | `nestedFieldTypes` array and manual `field.type === '...'` checks |
| `tabHasName` | `'name' in tab` in `convertTabs` |
| `fieldIsID` | `(field as FieldWithName).name !== 'id'` |
| `fieldShouldBeLocalized` | local `hasLocalizedProp` check (via wrapper) |

### `hasCrowdinLocalizationFlag`

Payload's `fieldShouldBeLocalized` returns `false` when a parent is already localized — nested fields inherit locale from the parent in Payload's DB model. For Crowdin sync, the opposite applies: when `localizedParent` is true, children are syncable even without their own `localized: true`.

```ts
const hasCrowdinLocalizationFlag = (field, localizedParent = false) =>
  localizedParent ||
  fieldShouldBeLocalized({ field, parentIsLocalized: localizedParent });
```

### `isCrowdinNestedDataField`

Extracted `fieldIsGroupType(field) || fieldIsArrayType(field)` for the duplicated group/array branches in `getLocalizedFields` (filter and map steps). Blocks keep a separate `fieldIsBlockType` path because block recursion differs.

## Not changed (Phase 2)

- `getLocalizedFields` remains a single 119-line function
- Container flattening (`convertTabs`, `getCollapsibleLocalizedFields`, `getRowLocalizedFields`) unchanged
- Crowdin-specific filters (`fieldCrowdinFileType`, `excludeBasedOnConfig`, `reLocalizeField`) unchanged
- No adoption of `flattenAllFields` / `flattenTopLevelFields` yet

## Test plan

- [x] `nx run plugin:test` — 222 tests pass
- [x] CI green on PR
- [x] No change to `getLocalizedFields` inline snapshots in `dev/src/tests/plugin/getLocalizedFields.test.ts` (integration coverage unchanged by this PR)

## Follow-up

Phase 2: extract `filterByCrowdinType`, `flattenContainerFields`, and `recurseNestedFields` helpers from `getLocalizedFields`, per refactoring-broad §6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved field detection and validation logic for nested structures and localization handling.
  * Enhanced internal field processing using standardized type-checking methods for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->