### PR TITLE
ci: verify Payload import maps are up to date

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm install
+      - name: Verify Payload import maps are up to date
+        run: |
+          npm run generate:importmaps
+          git diff --exit-code "dev/src/app/(payload)/admin/importMap.js" "dev-alternative-config/src/app/(payload)/admin/importMap.js" || (echo "::error::Payload import maps are stale. Run 'npm run generate:importmaps' and commit the updated files." && exit 1)
       - name: Typecheck (plugin build)
         run: npx nx run plugin:build
       - name: Typecheck (plugin unit tests)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ npm install
 npm run test
 ```
 
+After changing Payload admin components in `dev/` or `dev-alternative-config/`, regenerate import maps:
+
+```bash
+npm run generate:importmaps
+```
+
+CI fails if committed import maps are stale.
+
 Docs site:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "generate:importmaps": "cd dev && npm run generate:importmap && cd ../dev-alternative-config && npm run generate:importmap",
     "release": "nx build plugin && cd dist/plugin && npm publish",
     "test": "nx run-many --all --target=test",
     "docs:serve": "nx run docs-site:serve",


### PR DESCRIPTION
## Summary

- Add root `npm run generate:importmaps` script for `dev/` and `dev-alternative-config/`
- Fail CI when committed `importMap.js` files drift from `payload generate:importmap` output
- Document the workflow in README

Fresh follow-up to the import-map CI idea from the closed #328 branch.

## Test plan

- [x] `npm run generate:importmaps` runs locally
- [x] `git diff --exit-code` passes on current import maps
- [ ] CI passes on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Developer Experience**
  - Added a command to regenerate admin import maps across supported development configurations.
  - Documented when import maps must be regenerated.

- **CI**
  - Builds now verify that committed import maps are up to date.
  - Builds report errors when required import maps are missing, untracked, or differ from generated versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->